### PR TITLE
Task - Disable approve button if insufficient balance

### DIFF
--- a/apps/multisig/src/components/TransactionSidesheet/TransactionSidesheetFooter.tsx
+++ b/apps/multisig/src/components/TransactionSidesheet/TransactionSidesheetFooter.tsx
@@ -77,21 +77,29 @@ export const SignerCta: React.FC<{
     }
 
     const [connectedWalletBal] =
-      balances?.find(({ address }) => {
+      balances?.find(({ address, chainId }) => {
         const parsedAddress = Address.fromSs58(address)
-        return parsedAddress && !!user && parsedAddress.isEqual(user.injected.address)
+        return (
+          parsedAddress &&
+          !!user &&
+          parsedAddress.isEqual(user.injected.address) &&
+          chainId === t.multisig.chain.squidIds.chainData
+        )
       }) || []
+
     const availableBalance = connectedWalletBal?.transferable.planck ?? 0n
 
     return availableBalance >= txCost
   }, [
     asDraft,
+    existentialDepositLoadable.state,
+    existentialDepositLoadable.contents.amount,
     fee?.amount,
     firstApproval,
-    existentialDepositLoadable,
     balances,
     multisigDepositTotal.contents.amount,
     user,
+    t.multisig.chain.squidIds.chainData,
   ])
 
   // Check if the user has an account connected which can approve the transaction

--- a/apps/multisig/src/domains/balances/index.ts
+++ b/apps/multisig/src/domains/balances/index.ts
@@ -5,6 +5,7 @@ import { useBalances, useSetBalancesAddresses } from '@talismn/balances-react'
 import { useUser } from '@domains/auth'
 import { useEffect, useMemo } from 'react'
 import { atom, useRecoilValue, useSetRecoilState } from 'recoil'
+import { Address } from '../../util/addresses'
 
 import { TokenAugmented } from '../../layouts/Overview/Assets'
 
@@ -20,7 +21,10 @@ export const useAugmentedBalances = () => {
 
   const multisigBalances = !user
     ? balances
-    : balances?.find(({ address, chain }) => address !== user.injected.address.toSs58(chain))
+    : balances?.find(({ address }) => {
+        const parsedAddress = Address.fromSs58(address)
+        return parsedAddress && !parsedAddress.isEqual(user.injected.address)
+      })
 
   return useMemo(() => {
     if (!multisigBalances) return undefined
@@ -73,10 +77,7 @@ export const BalancesWatcher = () => {
 
   useSetBalancesAddresses(
     useMemo(
-      () =>
-        user
-          ? [...multisigAddresses, user?.injected.address].map(a => a.toSs58(selectedMultisig.chain))
-          : multisigAddresses.map(a => a.toSs58(selectedMultisig.chain)),
+      () => multisigAddresses.concat(user ? [user.injected.address] : []).map(a => a.toSs58(selectedMultisig.chain)),
       [multisigAddresses, selectedMultisig.chain, user]
     )
   )

--- a/apps/multisig/src/domains/balances/index.ts
+++ b/apps/multisig/src/domains/balances/index.ts
@@ -2,6 +2,7 @@ import { BaseToken, supportedChains } from '@domains/chains'
 import { aggregatedMultisigsState, selectedMultisigState } from '@domains/multisig'
 import { Balances } from '@talismn/balances'
 import { useBalances, useSetBalancesAddresses } from '@talismn/balances-react'
+import { useUser } from '@domains/auth'
 import { useEffect, useMemo } from 'react'
 import { atom, useRecoilValue, useSetRecoilState } from 'recoil'
 
@@ -15,9 +16,15 @@ export const balancesState = atom<Balances | undefined>({
 
 export const useAugmentedBalances = () => {
   const balances = useRecoilValue(balancesState)
+  const { user } = useUser()
+
+  const multisigBalances = !user
+    ? balances
+    : balances?.find(({ address, chain }) => address !== user.injected.address.toSs58(chain))
+
   return useMemo(() => {
-    if (!balances) return undefined
-    return balances.filterNonZero('total').sorted.reduce((acc: TokenAugmented[], b) => {
+    if (!multisigBalances) return undefined
+    return multisigBalances.filterNonZero('total').sorted.reduce((acc: TokenAugmented[], b) => {
       if (b.chain === null || !b.token) return acc
       const balanceChain = b.chain
 
@@ -49,14 +56,15 @@ export const useAugmentedBalances = () => {
         { details: token, balance: { avaliable, unavaliable }, price: b.rates?.usd || 0, id: b.id, balanceDetails: b },
       ]
     }, [])
-  }, [balances])
+  }, [multisigBalances])
 }
 
 export const BalancesWatcher = () => {
   const multisigs = useRecoilValue(aggregatedMultisigsState)
   const selectedMultisig = useRecoilValue(selectedMultisigState)
   const setBalances = useSetRecoilState(balancesState)
-  const addresses = useMemo(() => multisigs.map(({ proxyAddress }) => proxyAddress), [multisigs])
+  const { user } = useUser()
+  const multisigAddresses = useMemo(() => multisigs.map(({ proxyAddress }) => proxyAddress), [multisigs])
 
   // clean up for loading state
   useEffect(() => {
@@ -64,7 +72,13 @@ export const BalancesWatcher = () => {
   }, [multisigs, setBalances])
 
   useSetBalancesAddresses(
-    useMemo(() => addresses.map(a => a.toSs58(selectedMultisig.chain)), [addresses, selectedMultisig.chain])
+    useMemo(
+      () =>
+        user
+          ? [...multisigAddresses, user?.injected.address].map(a => a.toSs58(selectedMultisig.chain))
+          : multisigAddresses.map(a => a.toSs58(selectedMultisig.chain)),
+      [multisigAddresses, selectedMultisig.chain, user]
+    )
   )
 
   const balances = useBalances()


### PR DESCRIPTION
# Description

## ⛑️ **What was done:**

Disable Transaction sheet Approve button if selected account doesn't have sufficient funds to pay for the transaction cost + existential deposit, and display "Insufficient Balance" text.

## Technical:

- Set current logged in user balance address in `balances`. Check if currently logged in user balance is enough to cover transaction cost in `TransactionSidesheetFooter`.
- Currently logged in user address balance has to be filtered out in `useAugmentedBalances`, the consumers of this hook expects multisig balances only.
- Moved confirmation button text to `getButtonLabel` for better readability.


## Type of change

- [x] Task (non-breaking change which fixes an issue)

### 🧪 **How to test:**

Case A:

1. Create a multisig transaction
2. Log in with an account where the balance is smaller than the Estimated Fee and Reserve Amount  combined, they are displayed on the footer of the transaction summary.

Case B:
1. Login with an account with no balance
2. Create a multisig transaction
3. Check "Save as Draft"

Expected result:

Button should be enabled and display "Save as Draft"

### 🗒️ **Notes:**

- [x] My changes generate no new warnings
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes

### 🖼️ **Screenshots:**

#### Desktop:

3 accounts were used in this example:
- Dev 1 has plenty of funds to cover the transaction cost.
- Dev 2 has little over the transaction cots.
- Dev 3 is 0.0000283... short


https://github.com/TalismanSociety/signet-web/assets/47801291/8f0bde7f-f6fb-47a2-9120-9e944f67da78



