### PR TITLE
[REFACTOR] - Proxy Account founding info & Warning

### DIFF
--- a/apps/multisig/src/layouts/Overview/VaultOverview.tsx
+++ b/apps/multisig/src/layouts/Overview/VaultOverview.tsx
@@ -10,6 +10,9 @@ import { Fragment } from 'react'
 import { secondsToDuration } from '@util/misc'
 import { cn } from '@util/tailwindcss'
 import { clsx } from 'clsx'
+import { useNavigate } from 'react-router-dom'
+import useCopied from '@hooks/useCopied'
+import { Check, Copy } from '@talismn/icons'
 
 const showMemberState = atom<boolean>({
   key: 'dashboardShowMemberState',
@@ -21,6 +24,8 @@ export const VaultOverview: React.FC = () => {
   const [selectedMultisig] = useSelectedMultisig()
   const [showMembers, setShowMembers] = useRecoilState(showMemberState)
   const { contactByAddress } = useKnownAddresses(selectedMultisig.orgId)
+  const navigate = useNavigate()
+  const { copy, copied } = useCopied()
 
   return (
     <section className="flex flex-col p-[24px] rounded-2xl bg-gray-800">
@@ -37,15 +42,22 @@ export const VaultOverview: React.FC = () => {
         </div>
         <ChainPill chain={selectedMultisig.chain} identiconSize={24} />
       </div>
-      <div css={{ marginTop: 24 }}>
-        <p css={({ color }) => ({ color: color.offWhite, fontSize: 14, marginTop: 3 })}>Proxied Address</p>
-        <AccountDetails
-          chain={selectedMultisig.chain}
-          address={selectedMultisig.proxyAddress}
-          identiconSize={20}
-          withAddressTooltip
-          nameOrAddressOnly
-        />
+      <div className="mt-6 flex gap-6">
+        <Button variant="outlined" onClick={() => navigate('/send')}>
+          Send
+        </Button>
+        <Button
+          onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+            e.stopPropagation()
+            e.preventDefault()
+            copy(selectedMultisig.proxyAddress.toSs58(selectedMultisig.chain), 'Address copied!')
+          }}
+        >
+          <div className="flex items-center gap-2">
+            <div>Receive</div>
+            <div>{copied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}</div>
+          </div>
+        </Button>
       </div>
       <div
         css={{
@@ -92,15 +104,11 @@ export const VaultOverview: React.FC = () => {
             {selectedMultisig.threshold} of {selectedMultisig.signers.length} members
           </p>
         </div>
-        <div
-          css={{
-            button: { backgroundColor: 'var(--color-backgroundLight)', padding: '8px 12px' },
-          }}
-        >
+        <div>
           <Button variant="secondary" onClick={() => setShowMembers(!showMembers)}>
-            <div css={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-              {showMembers ? <EyeOff size={16} /> : <Eye size={16} />}
-              <p css={{ fontSize: 14, marginTop: 2 }}>{showMembers ? 'Hide' : 'Show'} Members</p>
+            <div className="flex items-center gap-3">
+              {showMembers ? <EyeOff size={18} /> : <Eye size={18} />}
+              <div className="mt-1">{showMembers ? 'Hide' : 'Show'} Members</div>
             </div>
           </Button>
         </div>

--- a/apps/multisig/src/layouts/Overview/VaultOverview.tsx
+++ b/apps/multisig/src/layouts/Overview/VaultOverview.tsx
@@ -50,7 +50,7 @@ export const VaultOverview: React.FC = () => {
           onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
             e.stopPropagation()
             e.preventDefault()
-            copy(selectedMultisig.proxyAddress.toSs58(selectedMultisig.chain), 'Address copied!')
+            copy(selectedMultisig.proxyAddress.toSs58(selectedMultisig.chain), 'Proxy address copied!')
           }}
         >
           <div className="flex items-center gap-2">

--- a/apps/multisig/src/layouts/Overview/VaultOverview.tsx
+++ b/apps/multisig/src/layouts/Overview/VaultOverview.tsx
@@ -10,9 +10,10 @@ import { Fragment } from 'react'
 import { secondsToDuration } from '@util/misc'
 import { cn } from '@util/tailwindcss'
 import { clsx } from 'clsx'
-import { useNavigate } from 'react-router-dom'
 import useCopied from '@hooks/useCopied'
 import { Check, Copy } from '@talismn/icons'
+import { Tooltip } from '@talismn/ui'
+import { Info } from '@talismn/icons'
 
 const showMemberState = atom<boolean>({
   key: 'dashboardShowMemberState',
@@ -24,7 +25,6 @@ export const VaultOverview: React.FC = () => {
   const [selectedMultisig] = useSelectedMultisig()
   const [showMembers, setShowMembers] = useRecoilState(showMemberState)
   const { contactByAddress } = useKnownAddresses(selectedMultisig.orgId)
-  const navigate = useNavigate()
   const { copy, copied } = useCopied()
 
   return (
@@ -42,22 +42,38 @@ export const VaultOverview: React.FC = () => {
         </div>
         <ChainPill chain={selectedMultisig.chain} identiconSize={24} />
       </div>
-      <div className="mt-6 flex gap-6">
-        <Button variant="outlined" onClick={() => navigate('/send')}>
-          Send
-        </Button>
-        <Button
-          onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-            e.stopPropagation()
-            e.preventDefault()
-            copy(selectedMultisig.proxyAddress.toSs58(selectedMultisig.chain), 'Proxy address copied!')
-          }}
-        >
-          <div className="flex items-center gap-2">
-            <div>Receive</div>
-            <div>{copied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}</div>
-          </div>
-        </Button>
+      <div className="flex justify-between gap-6 mt-6">
+        <div>
+          <p className="text-offWhite text-[14px]">Proxied Address</p>
+          <AccountDetails
+            chain={selectedMultisig.chain}
+            address={selectedMultisig.proxyAddress}
+            identiconSize={20}
+            withAddressTooltip
+            nameOrAddressOnly
+          />
+        </div>
+        <div className="flex items-center gap-4">
+          <Tooltip
+            content={
+              <p className="text-[12px]">{`This is the funding account address for ${selectedMultisig.chain.chainName} network only.`}</p>
+            }
+          >
+            <Info size={16} />
+          </Tooltip>
+          <Button
+            onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+              e.stopPropagation()
+              e.preventDefault()
+              copy(selectedMultisig.proxyAddress.toSs58(selectedMultisig.chain), 'Proxy address copied!')
+            }}
+          >
+            <div className="flex items-center gap-2">
+              <div>Receive</div>
+              <div>{copied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}</div>
+            </div>
+          </Button>
+        </div>
       </div>
       <div
         css={{
@@ -137,9 +153,19 @@ export const VaultOverview: React.FC = () => {
             </div>
           </div>
           <div className="flex flex-col flex-1">
-            <p css={({ color }) => ({ color: color.lightGrey, marginBottom: 8, fontSize: 14 })}>
-              Current Multisig Address
-            </p>
+            <div className="flex gap-4">
+              <p className="text-[14px] text-lightGrey">Current Multisig Address</p>
+              <Tooltip
+                content={
+                  <p className="text-[12px]">
+                    This multisig address is the address that controls the proxied account. Do not transfer funds to
+                    this address.
+                  </p>
+                }
+              >
+                <Info size={16} />
+              </Tooltip>
+            </div>
             <AccountDetails
               chain={selectedMultisig.chain}
               address={selectedMultisig.multisigAddress}

--- a/apps/multisig/src/layouts/Overview/VaultOverview.tsx
+++ b/apps/multisig/src/layouts/Overview/VaultOverview.tsx
@@ -13,7 +13,7 @@ import { clsx } from 'clsx'
 import useCopied from '@hooks/useCopied'
 import { Check, Copy } from '@talismn/icons'
 import { Tooltip } from '@talismn/ui'
-import { Info } from '@talismn/icons'
+import { Info, AlertCircle } from '@talismn/icons'
 
 const showMemberState = atom<boolean>({
   key: 'dashboardShowMemberState',
@@ -42,38 +42,35 @@ export const VaultOverview: React.FC = () => {
         </div>
         <ChainPill chain={selectedMultisig.chain} identiconSize={24} />
       </div>
-      <div className="flex justify-between gap-6 mt-6">
+      <div className="flex gap-6 mt-6">
         <div>
-          <p className="text-offWhite text-[14px]">Proxied Address</p>
+          <div className="flex gap-[8px]">
+            <p className="text-offWhite text-[14px]">Proxied Address</p>
+            <Tooltip
+              content={
+                <p className="text-[12px]">{`This is the funding account address for ${selectedMultisig.chain.chainName} network only.`}</p>
+              }
+            >
+              <Info size={16} />
+            </Tooltip>
+          </div>
           <AccountDetails
             chain={selectedMultisig.chain}
             address={selectedMultisig.proxyAddress}
             identiconSize={20}
             withAddressTooltip
             nameOrAddressOnly
+            disableCopy
           />
         </div>
-        <div className="flex items-center gap-4">
-          <Tooltip
-            content={
-              <p className="text-[12px]">{`This is the funding account address for ${selectedMultisig.chain.chainName} network only.`}</p>
-            }
-          >
-            <Info size={16} />
-          </Tooltip>
-          <Button
-            onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-              e.stopPropagation()
-              e.preventDefault()
-              copy(selectedMultisig.proxyAddress.toSs58(selectedMultisig.chain), 'Proxy address copied!')
-            }}
-          >
-            <div className="flex items-center gap-2">
-              <div>Receive</div>
-              <div>{copied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}</div>
-            </div>
-          </Button>
-        </div>
+        <Button
+          onClick={() => copy(selectedMultisig.proxyAddress.toSs58(selectedMultisig.chain), 'Proxy address copied!')}
+        >
+          <div className="flex items-center gap-2">
+            <div>Receive</div>
+            <div>{copied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}</div>
+          </div>
+        </Button>
       </div>
       <div
         css={{
@@ -163,7 +160,7 @@ export const VaultOverview: React.FC = () => {
                   </p>
                 }
               >
-                <Info size={16} />
+                <AlertCircle size={16} className="text-orange-400" />
               </Tooltip>
             </div>
             <AccountDetails

--- a/apps/multisig/src/layouts/Settings/InfoRow.tsx
+++ b/apps/multisig/src/layouts/Settings/InfoRow.tsx
@@ -1,10 +1,11 @@
-import { Info } from '@talismn/icons'
+import { Info, AlertCircle } from '@talismn/icons'
 import { Tooltip } from '@talismn/ui'
 import { cn } from '@util/tailwindcss'
 
 type Props = {
   label: string
   tooltip?: React.ReactNode
+  tooltipType?: 'info' | 'warning'
   labelClassName?: string
   className?: string
 }
@@ -14,6 +15,7 @@ export const SettingsInfoRow: React.FC<React.PropsWithChildren<Props>> = ({
   className,
   label,
   tooltip,
+  tooltipType = 'info',
   children,
 }) => (
   <div className={cn('flex flex-col gap-[4px] w-full', className)}>
@@ -21,7 +23,7 @@ export const SettingsInfoRow: React.FC<React.PropsWithChildren<Props>> = ({
       <p className={cn('text-[14px] mt-[2px] text-gray-200', labelClassName)}>{label}</p>
       {tooltip && (
         <Tooltip content={<p css={{ fontSize: 12 }}>{tooltip}</p>}>
-          <Info size={16} />
+          {tooltipType === 'warning' ? <AlertCircle size={16} className="text-orange-400" /> : <Info size={16} />}
         </Tooltip>
       )}
     </div>

--- a/apps/multisig/src/layouts/Settings/index.tsx
+++ b/apps/multisig/src/layouts/Settings/index.tsx
@@ -94,6 +94,7 @@ const Settings = () => {
             label="Multisig Address"
             tooltip="This multisig address is the address that controls the proxied account. It is derived from your multisig's members and threshold. Do not transfer funds to
             this address."
+            tooltipType="warning"
             labelClassName={multisig.proxies?.length === 0 ? 'text-red-500' : ''}
           >
             <AccountDetails address={newMultisigAddress} chain={multisig.chain} withAddressTooltip />

--- a/apps/multisig/src/layouts/Settings/index.tsx
+++ b/apps/multisig/src/layouts/Settings/index.tsx
@@ -18,7 +18,6 @@ import { useUser } from '@domains/auth'
 import { NameForm } from './NameForm'
 import { DescriptionForm } from './DescriptionForm'
 import { RecoverMultisig } from './RecoverMultisig'
-import { AlertTriangle } from '@talismn/icons'
 
 const Settings = () => {
   const [multisig] = useSelectedMultisig()
@@ -93,13 +92,10 @@ const Settings = () => {
           {/** third row: Multisig Address */}
           <SettingsInfoRow
             label="Multisig Address"
-            tooltip="This multisig address is the address that controls the proxied account. It is derived from your multisig's members and threshold."
+            tooltip="This multisig address is the address that controls the proxied account. It is derived from your multisig's members and threshold. Do not transfer funds to
+            this address."
             labelClassName={multisig.proxies?.length === 0 ? 'text-red-500' : ''}
           >
-            <div className="text-xl text-red-500 flex items-center gap-2">
-              <AlertTriangle size={16} />
-              <div className="mt-2">Do not transfer funds to this address</div>
-            </div>
             <AccountDetails address={newMultisigAddress} chain={multisig.chain} withAddressTooltip />
           </SettingsInfoRow>
           <div className="hidden md:block" />

--- a/apps/multisig/src/layouts/Settings/index.tsx
+++ b/apps/multisig/src/layouts/Settings/index.tsx
@@ -18,6 +18,7 @@ import { useUser } from '@domains/auth'
 import { NameForm } from './NameForm'
 import { DescriptionForm } from './DescriptionForm'
 import { RecoverMultisig } from './RecoverMultisig'
+import { AlertTriangle } from '@talismn/icons'
 
 const Settings = () => {
   const [multisig] = useSelectedMultisig()
@@ -95,6 +96,10 @@ const Settings = () => {
             tooltip="This multisig address is the address that controls the proxied account. It is derived from your multisig's members and threshold."
             labelClassName={multisig.proxies?.length === 0 ? 'text-red-500' : ''}
           >
+            <div className="text-xl text-red-500 flex items-center gap-2">
+              <AlertTriangle size={16} />
+              <div className="mt-2">Do not transfer funds here</div>
+            </div>
             <AccountDetails address={newMultisigAddress} chain={multisig.chain} withAddressTooltip />
           </SettingsInfoRow>
           <div className="hidden md:block" />

--- a/apps/multisig/src/layouts/Settings/index.tsx
+++ b/apps/multisig/src/layouts/Settings/index.tsx
@@ -98,7 +98,7 @@ const Settings = () => {
           >
             <div className="text-xl text-red-500 flex items-center gap-2">
               <AlertTriangle size={16} />
-              <div className="mt-2">Do not transfer funds here</div>
+              <div className="mt-2">Do not transfer funds to this address</div>
             </div>
             <AccountDetails address={newMultisigAddress} chain={multisig.chain} withAddressTooltip />
           </SettingsInfoRow>


### PR DESCRIPTION
# Description

## ⛑️ **What was done:**

- Removed AccountDetails component from /overview, added Send and Remove Buttons
- Added warning message under Multisig Address in '/settings'

## Type of change

- [x] Ready to merge

### 🧪 **How to test:**
1. Go to /overview
2. Click on "Receive" button

Expected: Proxy address should have been copied to clipboard and toast should be thrown

1. Go to /overview
2. Click on "Send" button

Expected: Should navigate to '/send'


### 🖼️ **Screenshots:**


https://github.com/TalismanSociety/signet-web/assets/47801291/1a863db6-1cfe-4f0a-912e-80cdb24cceb3



