### PR TITLE
[FEAT] - Disable tx execution if multisig doesn't have enough funds

### DIFF
--- a/apps/multisig/src/components/TransactionSidesheet/TransactionSidesheetFooter.tsx
+++ b/apps/multisig/src/components/TransactionSidesheet/TransactionSidesheetFooter.tsx
@@ -83,17 +83,16 @@ export const SignerCta: React.FC<{
     // No need to check for multisig balance if not going to execute the transaction
     if (asDraft || !readyToExecute || existentialDepositLoadable.state === 'loading') return true
 
-    const [multiSigTokenBalance] =
-      balances?.find(({ address, chainId }) => {
+    const availableBalance =
+      balances?.find(({ address, chainId, source }) => {
         const parsedAddress = Address.fromSs58(address)
         return (
           parsedAddress &&
           parsedAddress.isEqual(multisig.proxyAddress) &&
+          source === 'substrate-native' &&
           chainId === t.multisig.chain.squidIds.chainData
         )
-      }) || []
-
-    const availableBalance = multiSigTokenBalance?.transferable.planck ?? 0n
+      }).sum.planck.transferable ?? 0n
 
     const txTokensAmount = BigInt(
       t.decoded?.type === TransactionType.Vote ? voteSum?.amount.toString() ?? 0 : sumOutgoing?.amount.toString() ?? 0

--- a/apps/multisig/src/components/TransactionSidesheet/TransactionSidesheetFooter.tsx
+++ b/apps/multisig/src/components/TransactionSidesheet/TransactionSidesheetFooter.tsx
@@ -11,6 +11,7 @@ import {
   usePendingTransactions,
   useSelectedMultisig,
   calcSumOutgoing,
+  calcVoteSum,
 } from '@domains/multisig'
 import { Skeleton } from '@talismn/ui'
 import { balanceToFloat, formatUsd } from '@util/numbers'
@@ -46,6 +47,7 @@ export const SignerCta: React.FC<{
   const balances = useRecoilValue(balancesState)
   const [asDraft, setAsDraft] = useState(false)
   const [sumOutgoing] = useMemo(() => calcSumOutgoing(t), [t])
+  const voteSum = useMemo(() => calcVoteSum(t), [t])
   const [multisig] = useSelectedMultisig()
   const { transactions: pendingTransactions, loading: pendingLoading } = usePendingTransactions()
   const feeTokenPrice = useRecoilValueLoadable(tokenPriceState(fee?.token))
@@ -93,7 +95,11 @@ export const SignerCta: React.FC<{
 
     const availableBalance = multiSigTokenBalance?.transferable.planck ?? 0n
 
-    return availableBalance >= BigInt(sumOutgoing?.amount.toString() ?? 0)
+    const txTokensAmount = BigInt(
+      t.decoded?.type === TransactionType.Vote ? voteSum?.amount.toString() ?? 0 : sumOutgoing?.amount.toString() ?? 0
+    )
+
+    return availableBalance >= txTokensAmount
   }, [
     asDraft,
     balances,
@@ -101,7 +107,9 @@ export const SignerCta: React.FC<{
     multisig.proxyAddress,
     readyToExecute,
     sumOutgoing?.amount,
+    t.decoded?.type,
     t.multisig.chain.squidIds.chainData,
+    voteSum?.amount,
   ])
 
   const connectedAccountHasEnoughBalance: boolean = useMemo(() => {

--- a/apps/multisig/src/domains/multisig/index.ts
+++ b/apps/multisig/src/domains/multisig/index.ts
@@ -255,6 +255,31 @@ export const calcSumOutgoing = (t: Transaction): Balance[] => {
   }, [])
 }
 
+export const calcVoteSum = (t: Transaction): Balance | null => {
+  if (t.decoded?.type !== TransactionType.Vote || !t.decoded.voteDetails) return null
+
+  const { convictionVote, details, token } = t.decoded.voteDetails
+  const { Standard, SplitAbstain } = details
+
+  let amount: BN
+
+  // TODO: Add support to Split votes
+  switch (convictionVote) {
+    case 'SplitAbstain':
+      amount = Object.values(SplitAbstain!).reduce((acc, balance) => acc.add(balance), new BN(0))
+      break
+    case 'Standard':
+      amount = Standard?.balance!
+      break
+    default:
+      // Handle removeVote
+      amount = new BN(0)
+      break
+  }
+
+  return { amount, token }
+}
+
 interface ChangeConfigCall {
   section: 'utility'
   method: 'batchAll'


### PR DESCRIPTION
# Description

## ⛑️ **What was done:**

Disables execute transaction button if Multisig vault does not have enough funds for the Transfer or Vote transaction. The check **ONLY** occurs if the signer is the last signer and will execute the transaction.

- [x] New feature (non-breaking change which adds functionality)
- [x] Ready to merge

### 🧪 **How to test:**
1. Create a Transaction that exceeds the available balance

Expected:
- Signers up to the approval threshold -1 should be able to sign the tx
- Last signer (and executor) should not be able to sign the transaction


### 🖼️ **Screenshots:**


https://github.com/TalismanSociety/signet-web/assets/47801291/86a72e64-565e-4447-9c16-18fb95bc7c5b


