### PR TITLE
[HOTFIX] - show member button text-no-wrap, vault overview layout width

### DIFF
--- a/apps/multisig/src/layouts/Overview/VaultOverview.tsx
+++ b/apps/multisig/src/layouts/Overview/VaultOverview.tsx
@@ -121,7 +121,7 @@ export const VaultOverview: React.FC = () => {
           <Button variant="secondary" onClick={() => setShowMembers(!showMembers)}>
             <div className="flex items-center gap-3">
               {showMembers ? <EyeOff size={18} /> : <Eye size={18} />}
-              <div className="mt-1">{showMembers ? 'Hide' : 'Show'} Members</div>
+              <div className="mt-1 text-nowrap">{showMembers ? 'Hide' : 'Show'} Members</div>
             </div>
           </Button>
         </div>

--- a/apps/multisig/src/layouts/Overview/index.tsx
+++ b/apps/multisig/src/layouts/Overview/index.tsx
@@ -106,7 +106,7 @@ const Overview = () => {
   return (
     <div className="flex flex-col lg:flex-row gap-[16px] flex-1 w-[100px]">
       <div
-        className="flex flex-col gap-[16px] h-full w-full flex-1 lg:w-[100px] lg:flex-[5]"
+        className="flex flex-col gap-[16px] h-full w-full flex-1 lg:w-[100px] lg:flex-[7]"
         css={{ gridArea: 'overview-assets' }}
       >
         <VaultOverview />


### PR DESCRIPTION
# Description

## ⛑️ **What was done:**

Fixed "Show/Hide Members" button text wrapping.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Ready to merge


### 🖼️ **Screenshots:**

After: 

https://github.com/TalismanSociety/signet-web/assets/47801291/7fde6fc9-7548-42e7-96a9-04d9515eeda5



## Before:
![Screenshot 2024-06-03 at 12 24 25](https://github.com/TalismanSociety/signet-web/assets/47801291/574664d3-64a8-4328-bc2d-cbf79e6c6b43)




