### PR TITLE
fix: connectedAccountHasEnoughBalance

### DIFF
--- a/apps/multisig/src/components/TransactionSidesheet/TransactionSidesheetFooter.tsx
+++ b/apps/multisig/src/components/TransactionSidesheet/TransactionSidesheetFooter.tsx
@@ -119,18 +119,17 @@ export const SignerCta: React.FC<{
       txCost += BigInt(multisigDepositTotal.contents.amount?.toString() ?? 0)
     }
 
-    const [connectedWalletBal] =
-      balances?.find(({ address, chainId }) => {
+    const availableBalance =
+      balances?.find(({ address, chainId, source }) => {
         const parsedAddress = Address.fromSs58(address)
         return (
           parsedAddress &&
           !!user &&
           parsedAddress.isEqual(user.injected.address) &&
+          source === 'substrate-native' &&
           chainId === t.multisig.chain.squidIds.chainData
         )
-      }) || []
-
-    const availableBalance = connectedWalletBal?.transferable.planck ?? 0n
+      }).sum.planck.transferable ?? 0n
 
     return availableBalance >= txCost
   }, [


### PR DESCRIPTION
# Description


## ⛑️ **What was done:**

Fixed `connectedAccountHasEnoughBalance` returning `false` when connected account indeed has enough balance by correctly getting `availableBalance`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Ready to merge

