### PR TITLE
fix: /dapps Custom Input bug

### DIFF
--- a/apps/multisig/src/layouts/Dapps/index.tsx
+++ b/apps/multisig/src/layouts/Dapps/index.tsx
@@ -171,7 +171,9 @@ export const Dapps: React.FC = () => {
         const urlOnCurrentChain = getDappUrl(dapp)
         if (urlOnCurrentChain) return setInput(urlOnCurrentChain)
       }
-      closeIframe()
+      if (iframeRef.current) {
+        closeIframe()
+      }
     }
   }, [getDappUrl, input, selectedDapp])
 


### PR DESCRIPTION
# Description

Fix Custom Input in `/dapps` not working.

Check if `iframeRef.current` is not null before calling closeIframe fn.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Ready to merge

### 🖼️ **Screenshots:**


https://github.com/user-attachments/assets/8b7a2443-a180-4c12-a72f-76866404a768

