### PR TITLE
Fix- Prompt user to switch account

### DIFF
--- a/apps/multisig/src/components/AccountMenu/AccountsList.tsx
+++ b/apps/multisig/src/components/AccountMenu/AccountsList.tsx
@@ -15,9 +15,10 @@ export const blockAccountSwitcher = atom<boolean>({
   default: false,
 })
 
-export const AccountsList: React.FC<{ onBack?: () => void; hideHeader?: boolean }> = ({
+export const AccountsList: React.FC<{ onBack?: () => void; hideHeader?: boolean; onlyEthAccounts?: boolean }> = ({
   onBack,
   hideHeader = false,
+  onlyEthAccounts,
 }) => {
   const accounts = useRecoilValue(accountsState)
   const [query, setQuery] = useState('')
@@ -31,6 +32,9 @@ export const AccountsList: React.FC<{ onBack?: () => void; hideHeader?: boolean 
   const filteredAccounts = useMemo(() => {
     return accounts.filter(acc => {
       const isSelectedAccount = user?.injected?.address.isEqual(acc.address)
+      // If no filter is applied, show all accounts, otherwise filter by onlyEthAccounts
+      const shouldFilterAccount =
+        onlyEthAccounts !== undefined ? (onlyEthAccounts ? acc.address.isEthereum : !acc.address.isEthereum) : true
 
       let queryAddress: Address | false = false
       try {
@@ -42,9 +46,9 @@ export const AccountsList: React.FC<{ onBack?: () => void; hideHeader?: boolean 
 
       const isQueryMatch =
         !query || `${acc.meta.name} ${acc.address.toSs58()}`.toLowerCase().includes(query.toLowerCase())
-      return !isSelectedAccount && isQueryMatch
+      return !isSelectedAccount && isQueryMatch && shouldFilterAccount
     })
-  }, [accounts, user?.injected?.address, query])
+  }, [accounts, user?.injected?.address, onlyEthAccounts, query])
 
   const selectAccount = useCallback(
     async (account: InjectedAccount) => {
@@ -69,7 +73,7 @@ export const AccountsList: React.FC<{ onBack?: () => void; hideHeader?: boolean 
 
   if (accountToSignIn) {
     return (
-      <div className="flex flex-col gap-[4px] h-[210px] items-center justify-center">
+      <div className="flex flex-col gap-[4px] h-[210px] items-center justify-center bg-gray-700 rounded-[8px]">
         <div className="flex items-center gap-[8px] mb-[24px]">
           <CircularProgressIndicator />
           <p className="text-offWhite font-bold">Signing In</p>
@@ -100,7 +104,7 @@ export const AccountsList: React.FC<{ onBack?: () => void; hideHeader?: boolean 
         value={query}
         onChange={e => setQuery(e.target.value)}
       />
-      <div className="flex flex-col flex-1 items-start justify-start overflow-y-auto bg-gray-800 gap-[8px]">
+      <div className="flex flex-col flex-1 items-start justify-start overflow-y-auto bg-gray-800 gap-[8px] p-[8px] rounded-[8px]">
         {filteredAccounts.map(acc => (
           <Button
             variant="ghost"

--- a/apps/multisig/src/components/AccountMenu/AccountsList.tsx
+++ b/apps/multisig/src/components/AccountMenu/AccountsList.tsx
@@ -15,7 +15,10 @@ export const blockAccountSwitcher = atom<boolean>({
   default: false,
 })
 
-export const AccountsList: React.FC<{ onBack?: () => void }> = ({ onBack }) => {
+export const AccountsList: React.FC<{ onBack?: () => void; hideHeader?: boolean }> = ({
+  onBack,
+  hideHeader = false,
+}) => {
   const accounts = useRecoilValue(accountsState)
   const [query, setQuery] = useState('')
   const { user } = useUser()
@@ -81,27 +84,28 @@ export const AccountsList: React.FC<{ onBack?: () => void }> = ({ onBack }) => {
   }
 
   return (
-    <div className="flex flex-col gap-[4px] h-[210px] flex-1">
-      <div className="flex items-center justify-between ">
-        <Button size="icon" className="items-center" variant="ghost" onClick={onBack}>
-          <ChevronLeft size={14} />
-        </Button>
-        <h4 className="text-[14px] font-semibold mt-[3px]">Switch Account</h4>
-        <div className="w-[30px]" />
-      </div>
+    <div className="flex flex-col gap-[12px] h-[210px] flex-1">
+      {!hideHeader && (
+        <div className="flex items-center justify-between ">
+          <Button size="icon" className="items-center" variant="ghost" onClick={onBack}>
+            <ChevronLeft size={14} />
+          </Button>
+          <h4 className="text-[14px] font-semibold mt-[3px]">Switch Account</h4>
+          <div className="w-[30px]" />
+        </div>
+      )}
       <Input
         placeholder="Search by name or address..."
-        className="text-[14px] h-max min-h-max px-[12px] py-[8px] rounded-[8px]"
+        className="text-[14px] px-[12px] py-[9px] rounded-[8px]"
         value={query}
         onChange={e => setQuery(e.target.value)}
       />
-      <div className="w-full h-[1px] bg-gray-700" />
-      <div className="flex flex-col flex-1 items-start justify-start overflow-y-auto">
+      <div className="flex flex-col flex-1 items-start justify-start overflow-y-auto bg-gray-800 gap-[8px]">
         {filteredAccounts.map(acc => (
           <Button
             variant="ghost"
             size="lg"
-            className="h-max w-full py-[8px]"
+            className="h-max w-full py-[8px] bg-gray-700"
             key={acc.address.toSs58()}
             onClick={() => selectAccount(acc)}
           >

--- a/apps/multisig/src/components/AddMemberInput.tsx
+++ b/apps/multisig/src/components/AddMemberInput.tsx
@@ -34,7 +34,6 @@ export const AddMemberInput: React.FC<Props> = ({ chain, validateAddress, onNewA
   }
   const handleAddressChange = (address: Address | undefined, input: string) => {
     if (isChainAccountEth !== address?.isEthereum) {
-      console.log('Chain mismatch')
       setError(true)
     }
     if (!address) {

--- a/apps/multisig/src/components/AddMemberInput.tsx
+++ b/apps/multisig/src/components/AddMemberInput.tsx
@@ -17,6 +17,8 @@ type Props = {
 export const AddMemberInput: React.FC<Props> = ({ chain, validateAddress, onNewAddress, addresses, compactInput }) => {
   const [addressInput, setAddressInput] = useState('')
   const [address, setAddress] = useState<Address | undefined>()
+  const [error, setError] = useState<boolean>(false)
+  const isChainAccountEth = chain?.account === 'secp256k1'
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
@@ -30,32 +32,37 @@ export const AddMemberInput: React.FC<Props> = ({ chain, validateAddress, onNewA
       setAddress(undefined)
     }
   }
+  const handleAddressChange = (address: Address | undefined, input: string) => {
+    if (isChainAccountEth !== address?.isEthereum) {
+      console.log('Chain mismatch')
+      setError(true)
+    }
+    if (!address) {
+      setError(false)
+    }
+    setAddressInput(input)
+    setAddress(address)
+  }
 
   return (
-    <form
-      onSubmit={handleSubmit}
-      css={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 8,
-        width: '100%',
-      }}
-    >
-      <AddressInput
-        addresses={addresses}
-        value={addressInput}
-        compact={compactInput}
-        chain={chain}
-        onChange={(address, input) => {
-          setAddressInput(input)
-          setAddress(address)
-        }}
-      />
+    <div className="relative">
+      <form onSubmit={handleSubmit} className="flex items-center gap-[8px]">
+        <AddressInput
+          addresses={addresses}
+          value={addressInput}
+          compact={compactInput}
+          chain={chain}
+          onChange={handleAddressChange}
+        />
 
-      <Button disabled={!address} variant="outline" type="submit" className="px-[12px] gap-[4px]">
-        <Plus size={24} />
-        <p css={{ marginTop: 4, marginLeft: 8 }}>Add</p>
-      </Button>
-    </form>
+        <Button disabled={!address || error} variant="outline" type="submit" className="px-[12px] gap-[4px]">
+          <Plus size={24} />
+          <p css={{ marginTop: 4, marginLeft: 8 }}>Add</p>
+        </Button>
+      </form>
+      {error && (
+        <div className="absolute mt-[4px] text-orange-400 text-[14px]">{`Address format not compatible with ${chain?.chainName} chain`}</div>
+      )}
+    </div>
   )
 }

--- a/apps/multisig/src/layouts/AddVault/CreateVault/index.tsx
+++ b/apps/multisig/src/layouts/AddVault/CreateVault/index.tsx
@@ -274,7 +274,6 @@ const CreateMultisig = () => {
         <SelectChain
           header="Create Multisig"
           isChainAccountEth={isChainAccountEth}
-          augmentedAccountsLength={augmentedAccounts.length}
           onBack={onBackChain}
           onNext={onNextChain}
           setAddedAccounts={setAddedAccounts}

--- a/apps/multisig/src/layouts/AddVault/CreateVault/index.tsx
+++ b/apps/multisig/src/layouts/AddVault/CreateVault/index.tsx
@@ -253,9 +253,9 @@ const CreateMultisig = () => {
     updateSearchParm({ param: 'step', value: (step - 1).toString() })
   }, [step, updateSearchParm])
 
-  return (
-    <>
-      {step === Step.NameVault ? (
+  const renderStep = () => {
+    const stepMap: Record<Step, React.ReactElement> = {
+      [Step.NameVault]: (
         <NameVault
           header="Create Multisig"
           onBack={() => {
@@ -269,7 +269,8 @@ const CreateMultisig = () => {
           }}
           name={name}
         />
-      ) : step === Step.SelectFirstChain ? (
+      ),
+      [Step.SelectFirstChain]: (
         <SelectChain
           header="Create Multisig"
           isChainAccountEth={isChainAccountEth}
@@ -283,7 +284,8 @@ const CreateMultisig = () => {
           chain={chain}
           chains={filteredSupportedChains}
         />
-      ) : step === Step.MultisigConfig ? (
+      ),
+      [Step.MultisigConfig]: (
         <MultisigConfig
           header="Create Multisig"
           chain={chain}
@@ -297,7 +299,8 @@ const CreateMultisig = () => {
           members={augmentedAccounts}
           onMembersChange={setAddedAccounts}
         />
-      ) : step === Step.Confirmation ? (
+      ),
+      [Step.Confirmation]: (
         <Confirmation
           header="Create Multisig"
           onBack={onBackChain}
@@ -312,7 +315,8 @@ const CreateMultisig = () => {
           extrinsicsReady={transferProxyToMultisigIsReady && createProxyIsReady}
           existentialDeposit={initialVaultFundsLoadable}
         />
-      ) : step === Step.Transactions ? (
+      ),
+      [Step.Transactions]: (
         <SignTransactions
           chain={chain}
           created={created}
@@ -327,9 +331,12 @@ const CreateMultisig = () => {
           transferring={transferring}
           vaultDetailsString={vaultDetailsString}
         />
-      ) : null}
-    </>
-  )
+      ),
+    }
+    return stepMap[step] ?? null
+  }
+
+  return renderStep()
 }
 
 export default CreateMultisig

--- a/apps/multisig/src/layouts/AddVault/CreateVault/index.tsx
+++ b/apps/multisig/src/layouts/AddVault/CreateVault/index.tsx
@@ -35,6 +35,8 @@ export enum Step {
   Transactions,
 }
 
+export type Param = 'name' | 'step' | 'chainId' | 'threshold' | 'members'
+
 const CreateMultisig = () => {
   let firstChain = filteredSupportedChains[0]
   if (!firstChain) throw Error('no supported chains')
@@ -90,8 +92,6 @@ const CreateMultisig = () => {
   useEffect(() => {
     if (created) navigate('/overview')
   }, [created, navigate])
-
-  type Param = 'name' | 'step' | 'chainId' | 'threshold' | 'members'
 
   const updateSearchParm = useCallback(
     ({ param, value }: { param: Param; value: string }) => {
@@ -277,6 +277,8 @@ const CreateMultisig = () => {
           augmentedAccountsLength={augmentedAccounts.length}
           onBack={onBackChain}
           onNext={onNextChain}
+          setAddedAccounts={setAddedAccounts}
+          updateSearchParm={updateSearchParm}
           setChain={chain => {
             setChain(chain)
             updateSearchParm({ param: 'chainId', value: chain.id })

--- a/apps/multisig/src/layouts/AddVault/CreateVault/index.tsx
+++ b/apps/multisig/src/layouts/AddVault/CreateVault/index.tsx
@@ -52,7 +52,9 @@ const CreateMultisig = () => {
 
   const proxyDepositTotalLoadable = useRecoilValueLoadable(proxyDepositTotalSelector(chain.id))
 
-  const { augmentedAccounts, setAddedAccounts } = useAugmentedAccounts()
+  const isChainAccountEth = chain?.account === 'secp256k1'
+
+  const { augmentedAccounts, setAddedAccounts } = useAugmentedAccounts({ chain, isChainAccountEth })
 
   const [createdProxy, setCreatedProxy] = useState<Address | undefined>()
   const {
@@ -231,6 +233,8 @@ const CreateMultisig = () => {
       ) : step === Step.SelectFirstChain ? (
         <SelectChain
           header="Create Multisig"
+          isChainAccountEth={isChainAccountEth}
+          augmentedAccountsLength={augmentedAccounts.length}
           onBack={onBackChain}
           onNext={onNextChain}
           setChain={setChain}

--- a/apps/multisig/src/layouts/AddVault/ImportVault/index.tsx
+++ b/apps/multisig/src/layouts/AddVault/ImportVault/index.tsx
@@ -37,6 +37,8 @@ export const ImportVault: React.FC = () => {
   const { augmentedAccounts, setAddedAccounts } = useAugmentedAccounts()
   const { createOrganisation } = useCreateOrganisation()
 
+  const isChainAccountEth = chain?.account === 'secp256k1'
+
   const handleImport = useCallback(async () => {
     if (!proxiedAddress) return
     setImporting(true)
@@ -75,6 +77,7 @@ export const ImportVault: React.FC = () => {
         />
       ) : step === Step.SelectFirstChain ? (
         <SelectChain
+          isChainAccountEth={isChainAccountEth}
           header="Import Multisig"
           onBack={() => setStep(Step.NameVault)}
           onNext={() => setStep(Step.ProxiedAccountAddress)}

--- a/apps/multisig/src/layouts/AddVault/MultisigConfig/index.tsx
+++ b/apps/multisig/src/layouts/AddVault/MultisigConfig/index.tsx
@@ -10,7 +10,8 @@ type Props = {
   header?: string
   members: AugmentedAccount[]
   threshold: number
-  onMembersChange: React.Dispatch<React.SetStateAction<Address[]>>
+  setAddedAccounts?: React.Dispatch<React.SetStateAction<Address[]>>
+  onMembersChange?: React.Dispatch<React.SetStateAction<Address[]>>
   onThresholdChange: (threshold: number) => void
   onBack: () => void
   onNext: () => void
@@ -20,7 +21,7 @@ export const MultisigConfig: React.FC<Props> = ({
   chain,
   header,
   onBack,
-  onMembersChange,
+  setAddedAccounts,
   onNext,
   onThresholdChange,
   threshold,
@@ -32,7 +33,7 @@ export const MultisigConfig: React.FC<Props> = ({
         <h4 className="text-[14px] text-center font-bold mb-[4px]">{header}</h4>
         <h1>Multisig Configuration</h1>
       </div>
-      <AddMembers setAddedAccounts={onMembersChange} augmentedAccounts={members} chain={chain} />
+      <AddMembers setAddedAccounts={setAddedAccounts!} augmentedAccounts={members} chain={chain} />
       <ThresholdSettings membersCount={members.length} onChange={onThresholdChange} threshold={threshold} />
       <CancleOrNext
         block

--- a/apps/multisig/src/layouts/AddVault/common/NameVault.tsx
+++ b/apps/multisig/src/layouts/AddVault/common/NameVault.tsx
@@ -6,7 +6,7 @@ const NameVault = (props: {
   header?: string
   onBack?: () => void
   onNext: () => void
-  setName: React.Dispatch<React.SetStateAction<string>>
+  setName: (name: string) => void
   name: string
 }) => {
   const handleNext = (e: React.FormEvent) => {

--- a/apps/multisig/src/layouts/AddVault/common/SelectChain.tsx
+++ b/apps/multisig/src/layouts/AddVault/common/SelectChain.tsx
@@ -37,7 +37,7 @@ const SelectChain = ({
   setChain,
   chain,
   chains,
-  isChainAccountEth,
+  isChainAccountEth = false,
   augmentedAccountsLength,
 }: {
   header?: string
@@ -79,7 +79,7 @@ const SelectChain = ({
       {augmentedAccountsLength === 0 && (
         <div>
           <div className="text-center">{`Switch to a ${chain.chainName} compatible account to create a vault on this chain`}</div>
-          <AccountsList hideHeader={true} />
+          <AccountsList hideHeader={true} onlyEthAccounts={isChainAccountEth} />
         </div>
       )}
       <div className="pt-[36px]">

--- a/apps/multisig/src/layouts/AddVault/common/SelectChain.tsx
+++ b/apps/multisig/src/layouts/AddVault/common/SelectChain.tsx
@@ -44,7 +44,7 @@ const SelectChain = ({
   isChainAccountEth?: boolean
   onNext: () => void
   onBack: () => void
-  setChain: React.Dispatch<React.SetStateAction<Chain>>
+  setChain: (chain: Chain) => void
   chain: Chain
   chains: Chain[]
   augmentedAccountsLength?: number

--- a/apps/multisig/src/layouts/AddVault/common/SelectChain.tsx
+++ b/apps/multisig/src/layouts/AddVault/common/SelectChain.tsx
@@ -11,6 +11,8 @@ import {
 import { CancleOrNext } from './CancelOrNext'
 import { useCallback, useMemo } from 'react'
 import { AccountsList } from '@components/AccountMenu/AccountsList'
+import { Address } from '@util/addresses'
+import { Param } from '../CreateVault'
 
 const Group = (props: { chains: Chain[]; label: string }) => (
   <SelectGroup>
@@ -39,6 +41,8 @@ const SelectChain = ({
   chains,
   isChainAccountEth = false,
   augmentedAccountsLength,
+  setAddedAccounts,
+  updateSearchParm,
 }: {
   header?: string
   isChainAccountEth?: boolean
@@ -48,15 +52,22 @@ const SelectChain = ({
   chain: Chain
   chains: Chain[]
   augmentedAccountsLength?: number
+  setAddedAccounts?: React.Dispatch<React.SetStateAction<Address[]>>
+  updateSearchParm?: ({ param, value }: { param: Param; value: string }) => void
 }) => {
   const mainnets = useMemo(() => chains.filter(chain => !chain.isTestnet), [chains])
   const testnets = useMemo(() => chains.filter(chain => chain.isTestnet), [chains])
 
   const onValueChange = useCallback(
     (value: string) => {
-      setChain(chains.find(chain => chain.genesisHash === value) as Chain)
+      const selectedChain = chains.find(chain => chain.genesisHash === value) as Chain
+      if (selectedChain.account !== chain.account) {
+        setAddedAccounts?.([])
+        updateSearchParm?.({ param: 'members', value: selectedChain.account })
+      }
+      setChain(selectedChain)
     },
-    [setChain, chains]
+    [chains, chain.account, setChain, setAddedAccounts, updateSearchParm]
   )
 
   return (

--- a/apps/multisig/src/layouts/AddVault/common/SelectChain.tsx
+++ b/apps/multisig/src/layouts/AddVault/common/SelectChain.tsx
@@ -10,6 +10,7 @@ import {
 } from '@components/ui/select'
 import { CancleOrNext } from './CancelOrNext'
 import { useCallback, useMemo } from 'react'
+import { AccountsList } from '@components/AccountMenu/AccountsList'
 
 const Group = (props: { chains: Chain[]; label: string }) => (
   <SelectGroup>
@@ -36,13 +37,17 @@ const SelectChain = ({
   setChain,
   chain,
   chains,
+  isChainAccountEth,
+  augmentedAccountsLength,
 }: {
   header?: string
+  isChainAccountEth?: boolean
   onNext: () => void
   onBack: () => void
   setChain: React.Dispatch<React.SetStateAction<Chain>>
   chain: Chain
   chains: Chain[]
+  augmentedAccountsLength?: number
 }) => {
   const mainnets = useMemo(() => chains.filter(chain => !chain.isTestnet), [chains])
   const testnets = useMemo(() => chains.filter(chain => chain.isTestnet), [chains])
@@ -55,32 +60,41 @@ const SelectChain = ({
   )
 
   return (
-    <div className="grid items-center justify-center gap-[48px] w-full max-w-[540px]">
+    <div className="grid items-center justify-center gap-[12px] w-full max-w-[540px]">
       <div>
         <h4 className="text-[14px] text-center font-bold mb-[4px]">{header}</h4>
         <h1>Select a chain</h1>
         <p css={{ marginTop: 16, textAlign: 'center' }}>Select the chain for your Multisig</p>
       </div>
       <Select value={chain.genesisHash} onValueChange={onValueChange}>
-        <SelectTrigger className="max-w-[280px]">
+        <SelectTrigger className="w-[540px]">
           <SelectValue placeholder="Select Network" />
         </SelectTrigger>
-        <SelectContent className="grid gap-[0px] py-[4px]" position="item-aligned">
+        <SelectContent className="grid gap-[0px] py-[4px] w-[540px]" position="item-aligned">
           {mainnets.length > 0 && <Group chains={mainnets} label="Mainnets" />}
           {mainnets.length > 0 && testnets.length > 0 && <hr className="my-[12px]" />}
           {testnets.length > 0 && <Group chains={testnets} label="Testnets" />}
         </SelectContent>
       </Select>
-      <CancleOrNext
-        block
-        cancel={{
-          onClick: onBack,
-          children: 'Back',
-        }}
-        next={{
-          onClick: onNext,
-        }}
-      />
+      {augmentedAccountsLength === 0 && (
+        <div>
+          <div className="text-center">{`Switch to a ${chain.chainName} compatible account to create a vault on this chain`}</div>
+          <AccountsList hideHeader={true} />
+        </div>
+      )}
+      <div className="pt-[36px]">
+        <CancleOrNext
+          block
+          cancel={{
+            onClick: onBack,
+            children: 'Back',
+          }}
+          next={{
+            disabled: augmentedAccountsLength === 0,
+            onClick: onNext,
+          }}
+        />
+      </div>
     </div>
   )
 }

--- a/apps/multisig/src/layouts/AddVault/common/SelectChain.tsx
+++ b/apps/multisig/src/layouts/AddVault/common/SelectChain.tsx
@@ -13,6 +13,8 @@ import { useCallback, useMemo } from 'react'
 import { AccountsList } from '@components/AccountMenu/AccountsList'
 import { Address } from '@util/addresses'
 import { Param } from '../CreateVault'
+import { selectedAccountState } from '@domains/auth'
+import { useRecoilValue } from 'recoil'
 
 const Group = (props: { chains: Chain[]; label: string }) => (
   <SelectGroup>
@@ -40,23 +42,23 @@ const SelectChain = ({
   chain,
   chains,
   isChainAccountEth = false,
-  augmentedAccountsLength,
   setAddedAccounts,
   updateSearchParm,
 }: {
   header?: string
-  isChainAccountEth?: boolean
+  isChainAccountEth: boolean
   onNext: () => void
   onBack: () => void
   setChain: (chain: Chain) => void
   chain: Chain
   chains: Chain[]
-  augmentedAccountsLength?: number
   setAddedAccounts?: React.Dispatch<React.SetStateAction<Address[]>>
   updateSearchParm?: ({ param, value }: { param: Param; value: string }) => void
 }) => {
   const mainnets = useMemo(() => chains.filter(chain => !chain.isTestnet), [chains])
   const testnets = useMemo(() => chains.filter(chain => chain.isTestnet), [chains])
+  const selectedSigner = useRecoilValue(selectedAccountState)
+  const selectedSignerMatchesChainAccount = selectedSigner?.injected.address.isEthereum === isChainAccountEth
 
   const onValueChange = useCallback(
     (value: string) => {
@@ -87,7 +89,7 @@ const SelectChain = ({
           {testnets.length > 0 && <Group chains={testnets} label="Testnets" />}
         </SelectContent>
       </Select>
-      {augmentedAccountsLength === 0 && (
+      {!selectedSignerMatchesChainAccount && (
         <div>
           <div className="text-center">{`Switch to a ${chain.chainName} compatible account to create a vault on this chain`}</div>
           <AccountsList hideHeader={true} onlyEthAccounts={isChainAccountEth} />
@@ -101,7 +103,7 @@ const SelectChain = ({
             children: 'Back',
           }}
           next={{
-            disabled: augmentedAccountsLength === 0,
+            disabled: !selectedSignerMatchesChainAccount,
             onClick: onNext,
           }}
         />

--- a/apps/multisig/src/layouts/AddVault/common/useAugmentedAccounts.ts
+++ b/apps/multisig/src/layouts/AddVault/common/useAugmentedAccounts.ts
@@ -8,8 +8,9 @@ import { Chain } from '@domains/chains'
 export const useAugmentedAccounts = ({
   chain,
   isChainAccountEth,
-}: { chain?: Chain; isChainAccountEth?: boolean } = {}) => {
-  const [addedAccounts, setAddedAccounts] = useState<Address[]>([])
+  initialAddedAccounts,
+}: { chain?: Chain; isChainAccountEth?: boolean; initialAddedAccounts?: Address[] } = {}) => {
+  const [addedAccounts, setAddedAccounts] = useState<Address[]>(initialAddedAccounts || [])
   const [extensionAccounts] = useRecoilState(accountsState)
   const selectedSigner = useRecoilValue(selectedAccountState)
 

--- a/apps/multisig/src/layouts/AddVault/common/useAugmentedAccounts.ts
+++ b/apps/multisig/src/layouts/AddVault/common/useAugmentedAccounts.ts
@@ -3,11 +3,18 @@ import { useRecoilState, useRecoilValue } from 'recoil'
 import { accountsState } from '../../../domains/extension'
 import { selectedAccountState } from '../../../domains/auth'
 import { Address } from '../../../util/addresses'
+import { Chain } from '@domains/chains'
 
-export const useAugmentedAccounts = () => {
+export const useAugmentedAccounts = ({
+  chain,
+  isChainAccountEth,
+}: { chain?: Chain; isChainAccountEth?: boolean } = {}) => {
   const [addedAccounts, setAddedAccounts] = useState<Address[]>([])
   const [extensionAccounts] = useRecoilState(accountsState)
   const selectedSigner = useRecoilValue(selectedAccountState)
+
+  const selectedSignerMatchesChainAccount =
+    selectedSigner && chain ? selectedSigner.injected.address.isEthereum === isChainAccountEth : true
 
   const augmentedAccounts = useMemo(() => {
     const augmentedAddedAccounts = addedAccounts.map(a => {
@@ -21,7 +28,7 @@ export const useAugmentedAccounts = () => {
       }
     })
 
-    return selectedSigner
+    return selectedSigner && selectedSignerMatchesChainAccount
       ? [
           {
             address: selectedSigner.injected.address,
@@ -32,9 +39,9 @@ export const useAugmentedAccounts = () => {
           ...augmentedAddedAccounts,
         ]
       : augmentedAddedAccounts
-  }, [addedAccounts, extensionAccounts, selectedSigner])
+  }, [addedAccounts, extensionAccounts, selectedSigner, selectedSignerMatchesChainAccount])
 
-  // remove selected signer from addedAcounts list to prevent duplicate
+  // remove selected signer from addedAccounts list to prevent duplicate
   useEffect(() => {
     if (!selectedSigner) return
 


### PR DESCRIPTION
# Description

Prompts the user to switch account when creating a new Multisig if the selected chain account address type does not match the currently logged in account.

Form data is now stored in the URL, due to the fact that switching accounts caused to reload the app losing state and knocks the user back to the beginning of the multisig form.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Ready to merge

### 🧪 **How to test:**
- Login with a Substrate account
- Try to create a a new Multisig on Mythos

Expected:
- Be prompted to switch accounts when selecting chain


### 🖼️ **Screenshots:**

#### Desktop:


https://github.com/user-attachments/assets/d324ea4e-ee4e-4388-9ac9-4050a90ab60c

