### PR TITLE
Refactor: useKownAddresses

### DIFF
--- a/apps/multisig/src/components/AddressInput/AccountDetails.tsx
+++ b/apps/multisig/src/components/AddressInput/AccountDetails.tsx
@@ -19,6 +19,7 @@ type Props = {
   hideAddress?: boolean
   identiconSize?: number
   breakLine?: boolean
+  isNameLoading?: boolean
 }
 
 export const AccountDetails: React.FC<Props> = ({
@@ -33,6 +34,7 @@ export const AccountDetails: React.FC<Props> = ({
   breakLine,
   hideIdenticon = false,
   hideAddress = false,
+  isNameLoading = false,
 }) => {
   const { copy, copied } = useCopied()
 
@@ -54,6 +56,7 @@ export const AccountDetails: React.FC<Props> = ({
         nameOrAddressOnly={nameOrAddressOnly}
         breakLine={breakLine}
         hideAddress={hideAddress}
+        isNameLoading={isNameLoading}
       />
       {!disableCopy && (
         <div

--- a/apps/multisig/src/components/AddressInput/NameAndAddress.tsx
+++ b/apps/multisig/src/components/AddressInput/NameAndAddress.tsx
@@ -4,6 +4,7 @@ import { useOnchainIdentity } from '@domains/identity/useOnchainIdentity'
 import { Address } from '@util/addresses'
 import { Check } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
+import { CircularProgressIndicator } from '@talismn/ui'
 
 export const NameAndAddress: React.FC<{
   address: Address
@@ -12,7 +13,8 @@ export const NameAndAddress: React.FC<{
   nameOrAddressOnly?: boolean
   breakLine?: boolean
   hideAddress?: boolean
-}> = ({ address, name, chain, nameOrAddressOnly, breakLine, hideAddress }) => {
+  isNameLoading?: boolean
+}> = ({ address, name, chain, nameOrAddressOnly, breakLine, hideAddress, isNameLoading = false }) => {
   const { resolve } = useAzeroID()
   const [azeroId, setAzeroId] = useState<string | undefined>()
   const onchainIdentity = useOnchainIdentity(address, chain)
@@ -55,12 +57,23 @@ export const NameAndAddress: React.FC<{
     return null
   }, [address, azeroId, chain, name, nameOrAddressOnly, onchainIdentityUi])
 
-  if (!secondaryText)
+  if (!secondaryText) {
+    if (isNameLoading) {
+      return (
+        <div className="flex flex-col gap-1">
+          {true && !name && <CircularProgressIndicator size={16} />}
+          <p className="text-gray-200 text-[12px] leading-[1] whitespace-nowrap overflow-hidden text-ellipsis max-w-max w-full pt-[3px]">
+            {primaryText}
+          </p>
+        </div>
+      )
+    }
     return (
       <p className="text-offWhite overflow-hidden text-ellipsis mt-[3px] w-full max-w-max whitespace-nowrap">
         {primaryText}
       </p>
     )
+  }
 
   return (
     <div

--- a/apps/multisig/src/components/AddressInput/NameAndAddress.tsx
+++ b/apps/multisig/src/components/AddressInput/NameAndAddress.tsx
@@ -58,20 +58,23 @@ export const NameAndAddress: React.FC<{
   }, [address, azeroId, chain, name, nameOrAddressOnly, onchainIdentityUi])
 
   if (!secondaryText) {
-    if (isNameLoading) {
-      return (
-        <div className="flex flex-col gap-1">
-          {true && !name && <CircularProgressIndicator size={16} />}
-          <p className="text-gray-200 text-[12px] leading-[1] whitespace-nowrap overflow-hidden text-ellipsis max-w-max w-full pt-[3px]">
+    return (
+      <div className="flex flex-col gap-1">
+        {isNameLoading && !name ? (
+          <>
+            <CircularProgressIndicator size={16} />
+            {!nameOrAddressOnly && (
+              <p className="text-gray-200 text-[12px] leading-[1] whitespace-nowrap overflow-hidden text-ellipsis max-w-max w-full pt-[3px]">
+                {primaryText}
+              </p>
+            )}
+          </>
+        ) : (
+          <p className="text-offWhite overflow-hidden text-ellipsis mt-[3px] w-full max-w-max whitespace-nowrap">
             {primaryText}
           </p>
-        </div>
-      )
-    }
-    return (
-      <p className="text-offWhite overflow-hidden text-ellipsis mt-[3px] w-full max-w-max whitespace-nowrap">
-        {primaryText}
-      </p>
+        )}
+      </div>
     )
   }
 

--- a/apps/multisig/src/components/MemberRow/index.tsx
+++ b/apps/multisig/src/components/MemberRow/index.tsx
@@ -4,7 +4,13 @@ import { css } from '@emotion/css'
 import { ExternalLink, Trash } from '@talismn/icons'
 import { AccountDetails } from '@components/AddressInput/AccountDetails'
 
-const MemberRow = (props: { member: AugmentedAccount; chain: Chain; onDelete?: () => void; truncate?: boolean }) => {
+const MemberRow = (props: {
+  member: AugmentedAccount
+  chain: Chain
+  onDelete?: () => void
+  truncate?: boolean
+  isNameLoading?: boolean
+}) => {
   return (
     <div
       className={css`
@@ -27,6 +33,7 @@ const MemberRow = (props: { member: AugmentedAccount; chain: Chain; onDelete?: (
           disableCopy
           withAddressTooltip
           chain={props.chain}
+          isNameLoading={props.isNameLoading}
         />
         {props.member.you ? <span className="text-offWhite text-[14px]"> (You)</span> : null}
       </div>

--- a/apps/multisig/src/components/ScanVaults/VaultCard.tsx
+++ b/apps/multisig/src/components/ScanVaults/VaultCard.tsx
@@ -21,7 +21,8 @@ const VaultCard: React.FC<{ vault: ScannedVault; onAdded?: () => void }> = ({ on
   const { toast } = useToast()
   const setImportedTeams = useSetRecoilState(importedTeamsState)
   const navigate = useNavigate()
-  const { contactByAddress } = useKnownAddresses()
+  const signerAddresses = vault.multisig.signers.map(s => s.toSs58())
+  const { contactByAddress } = useKnownAddresses('', {}, showMultisig ? signerAddresses : [])
   useEffect(() => {
     if (add && showMultisig) setShowMultisig(false)
   }, [add, showMultisig])

--- a/apps/multisig/src/components/ScanVaults/VaultCard.tsx
+++ b/apps/multisig/src/components/ScanVaults/VaultCard.tsx
@@ -22,7 +22,7 @@ const VaultCard: React.FC<{ vault: ScannedVault; onAdded?: () => void }> = ({ on
   const setImportedTeams = useSetRecoilState(importedTeamsState)
   const navigate = useNavigate()
   const signerAddresses = vault.multisig.signers.map(s => s.toSs58())
-  const { contactByAddress } = useKnownAddresses('', {}, showMultisig ? signerAddresses : [])
+  const { contactByAddress } = useKnownAddresses({ addresses: showMultisig ? signerAddresses : [] })
   useEffect(() => {
     if (add && showMultisig) setShowMultisig(false)
   }, [add, showMultisig])

--- a/apps/multisig/src/components/SubstrateContractAbi/param-input/Address.tsx
+++ b/apps/multisig/src/components/SubstrateContractAbi/param-input/Address.tsx
@@ -7,7 +7,7 @@ import { useEffect, useState } from 'react'
 export const AddressParamInput: ParamInputComponent<string> = ({ chain, onChange, arg }) => {
   const [query, setQuery] = useState('')
   const [selectedMultisig] = useSelectedMultisig()
-  const { addresses } = useKnownAddresses(selectedMultisig.orgId, { includeSelectedMultisig: true })
+  const { addresses } = useKnownAddresses({ orgId: selectedMultisig.orgId, includeSelectedMultisig: true })
 
   useEffect(() => {
     if (!arg) setQuery('')

--- a/apps/multisig/src/components/TransactionSidesheet/TransactionSidesheetApprovals.tsx
+++ b/apps/multisig/src/components/TransactionSidesheet/TransactionSidesheetApprovals.tsx
@@ -7,8 +7,17 @@ import { Address } from '@util/addresses'
 import { useSelectedMultisig } from '@domains/multisig'
 
 export const TransactionSidesheetApprovals: React.FC<{ t: Transaction }> = ({ t }) => {
-  const { contactByAddress } = useKnownAddresses(t.multisig.orgId)
   const [{ isEthereumAccount }] = useSelectedMultisig()
+  const approversAddresses = Object.keys(t.approvals).reduce<string[]>((acc, address) => {
+    const decodedAddress = isEthereumAccount ? Address.fromSs58(address) : Address.fromPubKey(address)
+    if (decodedAddress) {
+      acc.push(decodedAddress.toSs58())
+    }
+    return acc
+  }, [])
+
+  console.log({ approversAddresses })
+  const { contactByAddress, isLoading } = useKnownAddresses(t.multisig.orgId, {}, approversAddresses)
   return (
     <div css={{ display: 'grid', gap: '14px' }}>
       {Object.entries(t.approvals).map(([address, approval]) => {
@@ -24,6 +33,7 @@ export const TransactionSidesheetApprovals: React.FC<{ t: Transaction }> = ({ t 
               <MemberRow
                 member={{ address: decodedAddress, nickname: contact?.name, you: contact?.extensionName !== undefined }}
                 chain={t.multisig.chain}
+                isNameLoading={isLoading}
               />
             </div>
             {(t.rawPending || t.executedAt) && (

--- a/apps/multisig/src/components/TransactionSidesheet/TransactionSidesheetApprovals.tsx
+++ b/apps/multisig/src/components/TransactionSidesheet/TransactionSidesheetApprovals.tsx
@@ -16,7 +16,6 @@ export const TransactionSidesheetApprovals: React.FC<{ t: Transaction }> = ({ t 
     return acc
   }, [])
 
-  console.log({ approversAddresses })
   const { contactByAddress, isLoading } = useKnownAddresses(t.multisig.orgId, {}, approversAddresses)
   return (
     <div css={{ display: 'grid', gap: '14px' }}>

--- a/apps/multisig/src/components/TransactionSidesheet/TransactionSidesheetApprovals.tsx
+++ b/apps/multisig/src/components/TransactionSidesheet/TransactionSidesheetApprovals.tsx
@@ -16,7 +16,7 @@ export const TransactionSidesheetApprovals: React.FC<{ t: Transaction }> = ({ t 
     return acc
   }, [])
 
-  const { contactByAddress, isLoading } = useKnownAddresses(t.multisig.orgId, {}, approversAddresses)
+  const { contactByAddress, isLoading } = useKnownAddresses({ orgId: t.multisig.orgId, addresses: approversAddresses })
   return (
     <div css={{ display: 'grid', gap: '14px' }}>
       {Object.entries(t.approvals).map(([address, approval]) => {

--- a/apps/multisig/src/domains/offchain-data/address-book/hooks/useGetAddressesByOrgIdAndAddress.ts
+++ b/apps/multisig/src/domains/offchain-data/address-book/hooks/useGetAddressesByOrgIdAndAddress.ts
@@ -45,8 +45,7 @@ const useGetAddressesByOrgIdAndAddress = (addresses: string[]) => {
   const [selectedMultisig] = useSelectedMultisig()
   return useQuery({
     queryKey: ['addresses', selectedMultisig.id, addresses],
-    queryFn: async () =>
-      fetchGraphQLData({ orgId: selectedMultisig.orgId, addresses, selectedAccount: selectedAccount! }),
+    queryFn: () => fetchGraphQLData({ orgId: selectedMultisig.orgId, addresses, selectedAccount: selectedAccount! }),
     enabled: !!selectedAccount && addresses.length > 0,
   })
 }

--- a/apps/multisig/src/domains/offchain-data/address-book/hooks/useGetAddressesByOrgIdAndAddress.ts
+++ b/apps/multisig/src/domains/offchain-data/address-book/hooks/useGetAddressesByOrgIdAndAddress.ts
@@ -1,0 +1,54 @@
+import { requestSignetBackend } from '@domains/offchain-data/hasura'
+import { selectedAccountState } from '@domains/auth'
+import { SignedInAccount } from '@domains/auth'
+import { useRecoilValue } from 'recoil'
+import { useQuery } from '@tanstack/react-query'
+import { ADDRESSES_BY_ORG_ID_AND_ADDRESS } from '@domains/offchain-data/address-book/queries/queries'
+import { useSelectedMultisig } from '@domains/multisig'
+import { Address } from '@util/addresses'
+import { Contact } from '../address-book'
+
+export type ContactAddress = Omit<Contact, 'orgId'> & { team_id?: string; org_id: string }
+export type ContactAddressIO = Omit<ContactAddress, 'address'> & { address: string }
+
+export type PaginatedAddresses = {
+  rows: ContactAddress[]
+  pageCount: number
+  rowCount: number
+}
+
+const fetchGraphQLData = async ({
+  orgId,
+  addresses,
+  selectedAccount,
+}: {
+  orgId: string
+  addresses: string[]
+  selectedAccount: SignedInAccount
+}): Promise<ContactAddress[]> => {
+  const { data } = await requestSignetBackend(
+    ADDRESSES_BY_ORG_ID_AND_ADDRESS,
+    {
+      orgId,
+      addresses,
+    },
+    selectedAccount
+  )
+
+  return (
+    data.address?.map((contact: ContactAddressIO) => ({ ...contact, address: Address.fromSs58(contact.address) })) ?? []
+  )
+}
+
+const useGetAddressesByOrgIdAndAddress = (addresses: string[]) => {
+  const selectedAccount = useRecoilValue(selectedAccountState)
+  const [selectedMultisig] = useSelectedMultisig()
+  return useQuery({
+    queryKey: ['addresses', selectedMultisig.id, addresses],
+    queryFn: async () =>
+      fetchGraphQLData({ orgId: selectedMultisig.orgId, addresses, selectedAccount: selectedAccount! }),
+    enabled: !!selectedAccount && addresses.length > 0,
+  })
+}
+
+export default useGetAddressesByOrgIdAndAddress

--- a/apps/multisig/src/domains/offchain-data/address-book/queries/queries.ts
+++ b/apps/multisig/src/domains/offchain-data/address-book/queries/queries.ts
@@ -70,6 +70,25 @@ export const PAGINATED_SUB_CATEGORIES_BY_ORG_ID = gql`
   }
 `
 
+export const ADDRESSES_BY_ORG_ID_AND_ADDRESS = gql`
+  query AddressesByOrgIdAndAddress($orgId: uuid!, $addresses: [String!]!) {
+    address(where: { org_id: { _eq: $orgId }, address: { _in: $addresses } }) {
+      id
+      org_id
+      name
+      address
+      category {
+        id
+        name
+      }
+      sub_category {
+        id
+        name
+      }
+    }
+  }
+`
+
 export const UPSERT_ADDRESSES = gql`
   mutation UpsertAddressesMutation($orgId: String!, $teamId: String!, $addressesInput: [AddressInput!]!) {
     UpsertAddresses(addressesInput: { addresses: $addressesInput, org_id: $orgId, team_id: $teamId }) {

--- a/apps/multisig/src/hooks/useKnownAddresses.ts
+++ b/apps/multisig/src/hooks/useKnownAddresses.ts
@@ -6,20 +6,27 @@ import { useMemo } from 'react'
 import { useSelectedMultisig } from '@domains/multisig'
 import { useSmartContracts } from '../domains/offchain-data/smart-contract'
 import { Contact } from '../domains/offchain-data/address-book/address-book'
+import useGetAddressesByOrgIdAndAddress from '../domains/offchain-data/address-book/hooks/useGetAddressesByOrgIdAndAddress'
 
 type ContactWithNameAndCategory = Partial<Contact> & AddressWithName
 
 export const useKnownAddresses = (
-  teamId?: string,
+  orgId?: string,
   {
     includeSelectedMultisig = false,
     includeContracts = false,
-  }: { includeSelectedMultisig?: boolean; includeContracts?: boolean } = {}
-): { addresses: ContactWithNameAndCategory[]; contactByAddress: Record<string, ContactWithNameAndCategory> } => {
+  }: { includeSelectedMultisig?: boolean; includeContracts?: boolean } = {},
+  addresses?: string[]
+): {
+  addresses: ContactWithNameAndCategory[]
+  contactByAddress: Record<string, ContactWithNameAndCategory>
+  isLoading: boolean
+} => {
   const extensionAccounts = useRecoilValue(accountsState)
   const addressBookByOrgId = useRecoilValue(addressBookByOrgIdState)
   const [multisig] = useSelectedMultisig()
   const { contracts } = useSmartContracts()
+  const { data: addressBookData, isLoading } = useGetAddressesByOrgIdAndAddress(addresses ?? [])
 
   const extensionContacts = extensionAccounts.reduce<AddressWithName[]>(
     (acc, { address, meta: { name = '' } = {} }) => {
@@ -37,9 +44,9 @@ export const useKnownAddresses = (
   )
 
   const addressBookContacts = useMemo(() => {
-    if (!teamId) return []
+    if (!orgId) return []
 
-    const addresses = addressBookByOrgId[teamId ?? ''] ?? []
+    const addresses = [...(addressBookByOrgId[orgId ?? ''] ?? []), ...(addressBookData ?? [])]
 
     return addresses.reduce<ContactWithNameAndCategory[]>((acc, { address, name, category, sub_category }) => {
       if (multisig.isEthereumAccount === address.isEthereum) {
@@ -54,7 +61,7 @@ export const useKnownAddresses = (
       }
       return acc
     }, [])
-  }, [addressBookByOrgId, multisig.isEthereumAccount, teamId])
+  }, [addressBookByOrgId, addressBookData, multisig.isEthereumAccount, orgId])
 
   const combinedList = useMemo(() => {
     let list = extensionContacts
@@ -130,5 +137,5 @@ export const useKnownAddresses = (
     }, {} as Record<string, ContactWithNameAndCategory>)
   }, [combinedList])
 
-  return { addresses: combinedList, contactByAddress }
+  return { addresses: combinedList, contactByAddress, isLoading }
 }

--- a/apps/multisig/src/hooks/useKnownAddresses.ts
+++ b/apps/multisig/src/hooks/useKnownAddresses.ts
@@ -10,14 +10,17 @@ import useGetAddressesByOrgIdAndAddress from '../domains/offchain-data/address-b
 
 type ContactWithNameAndCategory = Partial<Contact> & AddressWithName
 
-export const useKnownAddresses = (
-  orgId?: string,
-  {
-    includeSelectedMultisig = false,
-    includeContracts = false,
-  }: { includeSelectedMultisig?: boolean; includeContracts?: boolean } = {},
+export const useKnownAddresses = ({
+  orgId,
+  includeSelectedMultisig,
+  includeContracts,
+  addresses,
+}: {
+  orgId?: string
+  includeSelectedMultisig?: boolean
+  includeContracts?: boolean
   addresses?: string[]
-): {
+} = {}): {
   addresses: ContactWithNameAndCategory[]
   contactByAddress: Record<string, ContactWithNameAndCategory>
   isLoading: boolean
@@ -44,7 +47,7 @@ export const useKnownAddresses = (
   )
 
   const addressBookContacts = useMemo(() => {
-    if (!orgId) return []
+    if (!orgId || !addressBookData?.length) return []
 
     const addresses = [...(addressBookByOrgId[orgId ?? ''] ?? []), ...(addressBookData ?? [])]
 

--- a/apps/multisig/src/layouts/Collaborators/AddCollaboratorModal.tsx
+++ b/apps/multisig/src/layouts/Collaborators/AddCollaboratorModal.tsx
@@ -16,7 +16,7 @@ export const AddCollaboratorModal: React.FC<Props> = ({ isOpen, onClose }) => {
   const [selectedMultisig] = useSelectedMultisig()
   const [address, setAddress] = useState<Address | undefined>()
   const [error, setError] = useState<boolean>(false)
-  const { addresses } = useKnownAddresses(selectedMultisig.orgId)
+  const { addresses } = useKnownAddresses({ orgId: selectedMultisig.orgId })
   const { addCollaborator, adding } = useAddOrgCollaborator()
 
   const handleAddressChange = (address: Address | undefined) => {

--- a/apps/multisig/src/layouts/Collaborators/CollaboratorRow.tsx
+++ b/apps/multisig/src/layouts/Collaborators/CollaboratorRow.tsx
@@ -14,7 +14,7 @@ export const CollaboratorRow: React.FC<{ orgId: string; userId: string; address:
   userId,
   address,
 }) => {
-  const { contactByAddress } = useKnownAddresses(orgId, { includeContracts: true })
+  const { contactByAddress, isLoading } = useKnownAddresses(orgId, { includeContracts: true }, [address.toSs58()])
   const { deleteCollaborator, deleting } = useDeleteCollaborator()
   const { isCollaborator } = useUser()
 
@@ -25,7 +25,12 @@ export const CollaboratorRow: React.FC<{ orgId: string; userId: string; address:
   return (
     <div className="w-full bg-gray-900 p-[16px] rounded-[12px] flex items-center justify-between">
       <div>
-        <AccountDetails address={address} name={contactByAddress?.[address.toSs58()]?.name} withAddressTooltip />
+        <AccountDetails
+          address={address}
+          name={contactByAddress?.[address.toSs58()]?.name}
+          withAddressTooltip
+          isNameLoading={isLoading}
+        />
       </div>
       {!isCollaborator && (
         <Tooltip content="Remove collaborator">

--- a/apps/multisig/src/layouts/Collaborators/CollaboratorRow.tsx
+++ b/apps/multisig/src/layouts/Collaborators/CollaboratorRow.tsx
@@ -14,7 +14,11 @@ export const CollaboratorRow: React.FC<{ orgId: string; userId: string; address:
   userId,
   address,
 }) => {
-  const { contactByAddress, isLoading } = useKnownAddresses(orgId, { includeContracts: true }, [address.toSs58()])
+  const { contactByAddress, isLoading } = useKnownAddresses({
+    orgId,
+    includeContracts: true,
+    addresses: [address.toSs58()],
+  })
   const { deleteCollaborator, deleting } = useDeleteCollaborator()
   const { isCollaborator } = useUser()
 

--- a/apps/multisig/src/layouts/NewTransaction/Multisend/index.tsx
+++ b/apps/multisig/src/layouts/NewTransaction/Multisend/index.tsx
@@ -31,7 +31,7 @@ const MultiSend = () => {
   const apiLoadable = useRecoilValueLoadable(pjsApiSelector(multisig.chain.genesisHash))
   const { toast } = useToast()
   const permissions = hasPermission(multisig, 'transfer')
-  const { addresses } = useKnownAddresses(multisig.orgId)
+  const { addresses } = useKnownAddresses({ orgId: multisig.orgId })
   const newSends = useRecoilValue(multisendSendsAtom)
   const unit = useRecoilValue(multisendAmountUnitAtom)
   const token = useRecoilValue(multisendTokenAtom)

--- a/apps/multisig/src/layouts/NewTransaction/Send/DetailsForm.tsx
+++ b/apps/multisig/src/layouts/NewTransaction/Send/DetailsForm.tsx
@@ -69,7 +69,7 @@ export const DetailsForm: React.FC<Props> = ({
 }) => {
   const [addressError, setAddressError] = useState<boolean>(false)
   const [multisig] = useSelectedMultisig()
-  const { addresses } = useKnownAddresses(multisig.orgId)
+  const { addresses } = useKnownAddresses({ orgId: multisig.orgId })
   const { hasDelayedPermission, hasNonDelayedPermission } = hasPermission(multisig, 'transfer')
   const vestingConsts = useRecoilValueLoadable(vestingConstsSelector(multisig.chain.genesisHash))
 

--- a/apps/multisig/src/layouts/Overview/Transactions/TransactionDetailsExpandable.tsx
+++ b/apps/multisig/src/layouts/Overview/Transactions/TransactionDetailsExpandable.tsx
@@ -116,7 +116,7 @@ const MultisigCallDataBox: React.FC<{ calldata: `0x${string}`; genesisHash: stri
 }
 
 const ChangeConfigExpandedDetails = ({ t }: { t: Transaction }) => {
-  const { contactByAddress } = useKnownAddresses(t.multisig.orgId)
+  const { contactByAddress } = useKnownAddresses({ orgId: t.multisig.orgId })
   return (
     <div>
       <div css={{ display: 'grid', gap: 12, marginTop: '8px' }}>
@@ -155,7 +155,7 @@ const ChangeConfigExpandedDetails = ({ t }: { t: Transaction }) => {
 
 const MultiSendExpandedDetails = ({ t }: { t: Transaction }) => {
   const recipientAddresses = t.decoded?.recipients.map(r => r.address.toSs58())
-  const { contactByAddress, isLoading } = useKnownAddresses(t.multisig.orgId, {}, recipientAddresses)
+  const { contactByAddress, isLoading } = useKnownAddresses({ orgId: t.multisig.orgId, addresses: recipientAddresses })
   const shouldDisplayCategory =
     t.decoded?.recipients.some(r => contactByAddress[r.address.toSs58()]?.category) || isLoading
   const shouldDisplaySubcategory =
@@ -325,13 +325,11 @@ const TransactionDetailsHeaderContent: React.FC<{ t: Transaction }> = ({ t }) =>
   const recipients = t.decoded?.recipients || []
   const [recipient] = t.decoded?.recipients || []
   const recipientAddress = recipient?.address.toSs58()
-  const { contactByAddress, isLoading } = useKnownAddresses(
-    t.multisig.orgId,
-    {
-      includeContracts: true,
-    },
-    recipients.length === 1 && recipientAddress ? [recipientAddress] : []
-  )
+  const { contactByAddress, isLoading } = useKnownAddresses({
+    orgId: t.multisig.orgId,
+    includeContracts: true,
+    addresses: recipients.length === 1 && recipientAddress ? [recipientAddress] : [],
+  })
 
   if (!t.decoded) return null
 

--- a/apps/multisig/src/layouts/Overview/Transactions/TransactionDetailsExpandable.tsx
+++ b/apps/multisig/src/layouts/Overview/Transactions/TransactionDetailsExpandable.tsx
@@ -322,15 +322,20 @@ function AdvancedExpendedDetails({
 }
 
 const TransactionDetailsHeaderContent: React.FC<{ t: Transaction }> = ({ t }) => {
-  const { contactByAddress } = useKnownAddresses(t.multisig.orgId, {
-    includeContracts: true,
-  })
   const recipients = t.decoded?.recipients || []
+  const [recipient] = t.decoded?.recipients || []
+  const recipientAddress = recipient?.address.toSs58()
+  const { contactByAddress, isLoading } = useKnownAddresses(
+    t.multisig.orgId,
+    {
+      includeContracts: true,
+    },
+    recipients.length === 1 && recipientAddress ? [recipientAddress] : []
+  )
 
   if (!t.decoded) return null
 
   if (t.decoded.type === TransactionType.Transfer) {
-    const [recipient] = t.decoded.recipients
     if (recipient)
       return (
         <div className="bg-gray-500 p-[4px] px-[8px] rounded-[8px] max-w-[180px] [&>div>p]:text-[14px]">
@@ -342,6 +347,7 @@ const TransactionDetailsHeaderContent: React.FC<{ t: Transaction }> = ({ t }) =>
             nameOrAddressOnly
             identiconSize={16}
             disableCopy
+            isNameLoading={isLoading}
           />
         </div>
       )

--- a/apps/multisig/src/layouts/Overview/Transactions/TransactionSummaryRow.tsx
+++ b/apps/multisig/src/layouts/Overview/Transactions/TransactionSummaryRow.tsx
@@ -38,9 +38,10 @@ const TransactionSummaryRow = ({
   showShareButton?: boolean
   onClick?: () => void
 }) => {
-  const { contactByAddress, isLoading } = useKnownAddresses(t.multisig.orgId, {}, [
-    t?.draft?.creator.address.toSs58() || '',
-  ])
+  const { contactByAddress, isLoading } = useKnownAddresses({
+    orgId: t.multisig.orgId,
+    addresses: [t?.draft?.creator.address.toSs58() || ''],
+  })
   const sumOutgoing: Balance[] = useMemo(() => calcSumOutgoing(t), [t])
   const combinedView = useRecoilValue(combinedViewState)
   const tokenPrices = useRecoilValueLoadable(tokenPricesState(sumOutgoing.map(b => b.token)))

--- a/apps/multisig/src/layouts/Overview/Transactions/TransactionSummaryRow.tsx
+++ b/apps/multisig/src/layouts/Overview/Transactions/TransactionSummaryRow.tsx
@@ -38,7 +38,9 @@ const TransactionSummaryRow = ({
   showShareButton?: boolean
   onClick?: () => void
 }) => {
-  const { contactByAddress } = useKnownAddresses(t.multisig.orgId)
+  const { contactByAddress, isLoading } = useKnownAddresses(t.multisig.orgId, {}, [
+    t?.draft?.creator.address.toSs58() || '',
+  ])
   const sumOutgoing: Balance[] = useMemo(() => calcSumOutgoing(t), [t])
   const combinedView = useRecoilValue(combinedViewState)
   const tokenPrices = useRecoilValueLoadable(tokenPricesState(sumOutgoing.map(b => b.token)))
@@ -157,6 +159,7 @@ const TransactionSummaryRow = ({
                     withAddressTooltip
                     nameOrAddressOnly
                     disableCopy
+                    isNameLoading={isLoading}
                   />
                 </div>
               </div>

--- a/apps/multisig/src/layouts/Overview/VaultOverview.tsx
+++ b/apps/multisig/src/layouts/Overview/VaultOverview.tsx
@@ -24,8 +24,9 @@ const showMemberState = atom<boolean>({
 export const VaultOverview: React.FC = () => {
   const [selectedMultisig] = useSelectedMultisig()
   const [showMembers, setShowMembers] = useRecoilState(showMemberState)
-  const { contactByAddress } = useKnownAddresses(selectedMultisig.orgId)
   const { copy, copied } = useCopied()
+  const signersAddresses = selectedMultisig.signers.map(signer => signer.toSs58())
+  const { contactByAddress, isLoading } = useKnownAddresses(selectedMultisig.orgId, {}, signersAddresses)
 
   return (
     <section className="flex flex-col p-[24px] rounded-2xl bg-gray-800">
@@ -145,6 +146,7 @@ export const VaultOverview: React.FC = () => {
                   identiconSize={20}
                   nameOrAddressOnly
                   withAddressTooltip
+                  isNameLoading={isLoading}
                 />
               ))}
             </div>

--- a/apps/multisig/src/layouts/Overview/VaultOverview.tsx
+++ b/apps/multisig/src/layouts/Overview/VaultOverview.tsx
@@ -26,7 +26,10 @@ export const VaultOverview: React.FC = () => {
   const [showMembers, setShowMembers] = useRecoilState(showMemberState)
   const { copy, copied } = useCopied()
   const signersAddresses = selectedMultisig.signers.map(signer => signer.toSs58())
-  const { contactByAddress, isLoading } = useKnownAddresses(selectedMultisig.orgId, {}, signersAddresses)
+  const { contactByAddress, isLoading } = useKnownAddresses({
+    orgId: selectedMultisig.orgId,
+    addresses: signersAddresses,
+  })
 
   return (
     <section className="flex flex-col p-[24px] rounded-2xl bg-gray-800">

--- a/apps/multisig/src/layouts/Settings/RecoverMultisig.tsx
+++ b/apps/multisig/src/layouts/Settings/RecoverMultisig.tsx
@@ -25,10 +25,11 @@ type Props = {
 const ScannedMultisigs: React.FC<{
   multisigs: { signers: Address[]; threshold: number; address: Address }[]
   chain: Chain
-  teamId: string
+  orgId: string
   onSelect: (multisig: { signers: Address[]; threshold: number; address: Address }) => void
-}> = ({ chain, multisigs, onSelect, teamId }) => {
-  const { contactByAddress } = useKnownAddresses(teamId)
+}> = ({ chain, multisigs, onSelect, orgId }) => {
+  const signersAddresses = useMemo(() => multisigs.flatMap(m => m.signers.map(signer => signer.toSs58())), [multisigs])
+  const { contactByAddress, isLoading } = useKnownAddresses(orgId, {}, signersAddresses)
   return (
     <div className="grid gap-[8px] max-h-[400px] overflow-y-auto">
       {multisigs.map(multisig => (
@@ -66,6 +67,7 @@ const ScannedMultisigs: React.FC<{
                     name={contactByAddress[signer.toSs58()]?.name}
                     withAddressTooltip
                     nameOrAddressOnly
+                    isNameLoading={isLoading}
                   />
                 </div>
               ))}
@@ -184,7 +186,7 @@ export const RecoverMultisig: React.FC<Props> = ({ multisig }) => {
               )}
               <ScannedMultisigs
                 chain={multisig.chain}
-                teamId={multisig.id}
+                orgId={multisig.id}
                 multisigs={applicableMultisigs.map(({ multisigAddress, signers, threshold }) => ({
                   address: multisigAddress,
                   signers,

--- a/apps/multisig/src/layouts/Settings/RecoverMultisig.tsx
+++ b/apps/multisig/src/layouts/Settings/RecoverMultisig.tsx
@@ -29,7 +29,7 @@ const ScannedMultisigs: React.FC<{
   onSelect: (multisig: { signers: Address[]; threshold: number; address: Address }) => void
 }> = ({ chain, multisigs, onSelect, orgId }) => {
   const signersAddresses = useMemo(() => multisigs.flatMap(m => m.signers.map(signer => signer.toSs58())), [multisigs])
-  const { contactByAddress, isLoading } = useKnownAddresses(orgId, {}, signersAddresses)
+  const { contactByAddress, isLoading } = useKnownAddresses({ orgId, addresses: signersAddresses })
   return (
     <div className="grid gap-[8px] max-h-[400px] overflow-y-auto">
       {multisigs.map(multisig => (

--- a/apps/multisig/src/layouts/Settings/SignersSettings.tsx
+++ b/apps/multisig/src/layouts/Settings/SignersSettings.tsx
@@ -24,7 +24,7 @@ export const SignersSettings: React.FC<Props> = ({ capHeight, editable, error, m
     addresses: knownAddresses,
     contactByAddress,
     isLoading,
-  } = useKnownAddresses(multisig.orgId, {}, membersAddresses)
+  } = useKnownAddresses({ orgId: multisig.orgId, addresses: membersAddresses })
   const prevLength = useRef(members.length)
   const scrollView = useRef<HTMLDivElement>(null)
 

--- a/apps/multisig/src/layouts/Settings/SignersSettings.tsx
+++ b/apps/multisig/src/layouts/Settings/SignersSettings.tsx
@@ -19,7 +19,12 @@ type Props = {
 }
 
 export const SignersSettings: React.FC<Props> = ({ capHeight, editable, error, members, multisig, onChange }) => {
-  const { addresses: knownAddresses, contactByAddress } = useKnownAddresses(multisig.orgId)
+  const membersAddresses = members.map(m => m.toSs58())
+  const {
+    addresses: knownAddresses,
+    contactByAddress,
+    isLoading,
+  } = useKnownAddresses(multisig.orgId, {}, membersAddresses)
   const prevLength = useRef(members.length)
   const scrollView = useRef<HTMLDivElement>(null)
 
@@ -62,6 +67,7 @@ export const SignersSettings: React.FC<Props> = ({ capHeight, editable, error, m
                 disableCopy
                 chain={multisig.chain}
                 withAddressTooltip
+                isNameLoading={isLoading}
               />
               <Button
                 disabled={!editable}

--- a/apps/multisig/src/layouts/SmartContracts/DeployContractExpandedDetails.tsx
+++ b/apps/multisig/src/layouts/SmartContracts/DeployContractExpandedDetails.tsx
@@ -32,7 +32,8 @@ const IS_ADDRESS: Record<string, boolean> = {
 export const DeployContractExpandedDetails: React.FC<{ t: Transaction }> = ({ t }) => {
   const { api } = useApi(t.multisig.chain.genesisHash)
   const { decimal, symbol } = useTokenByChain(t.multisig.chain.genesisHash)
-  const { contactByAddress } = useKnownAddresses(t.multisig.orgId, {
+  const { contactByAddress } = useKnownAddresses({
+    orgId: t.multisig.orgId,
     includeContracts: true,
     includeSelectedMultisig: true,
   })

--- a/apps/multisig/src/layouts/SmartContracts/SmartContractCallExpandedDetails.tsx
+++ b/apps/multisig/src/layouts/SmartContracts/SmartContractCallExpandedDetails.tsx
@@ -37,7 +37,8 @@ export const SmartContractCallExpandedDetails: React.FC<{ t: Transaction }> = ({
   const { api } = useApi(t.multisig.chain.genesisHash)
   const { contract, contractDetails, loading } = useContractByAddress(t.decoded?.contractCall?.address, api)
   const { symbol, decimal } = useTokenByChain(t.multisig.chain.genesisHash)
-  const { contactByAddress } = useKnownAddresses(t.multisig.orgId, {
+  const { contactByAddress } = useKnownAddresses({
+    orgId: t.multisig.orgId,
     includeContracts: true,
     includeSelectedMultisig: true,
   })


### PR DESCRIPTION
### Description

Refactored `useKnownAddresses` hook to handle fetching contacts by their addresses, instead of relying on `addressBookByOrgIdState` atom which is populated by `AddressBookWatcher` that polls 1000 contact addresses, categories and subcategories every 10 seconds.

This is the first step towards moving away from the `AddressBookWatcher` pattern. Next will be an `AddresssInput` refactor to be an infinite, scrollable and searchable input that fetches X contacts at a time.

### Components refactored:

- [x] VaultCard
- [ ] Address // Depends on Address input refactor
- [x] TransactionSideSheetApprovals
- [x] AddMembers // No changes required
- [ ] AddColaboratorModal // Depends on Address input refactor
- [x] CollaboratorRow
- [ ] Multisend/index // Actually being used in AddressInputCell, depends on Address input refactor
- [ ] DetailsForm  // Depends on Address input refactor
- [x] VaultOverview
- [x] TransactionDetailsExpandable
- [x] TransactionSummaryRow
- [x] RecoverMultisig
- [x] SignersSettings // Partially, depends on Address input refactor