### PR TITLE
fix: Add address when importing multisig

### DIFF
--- a/apps/multisig/src/layouts/AddVault/ImportVault/index.tsx
+++ b/apps/multisig/src/layouts/AddVault/ImportVault/index.tsx
@@ -103,7 +103,7 @@ export const ImportVault: React.FC = () => {
           onBack={() => setStep(Step.ProxiedAccountAddress)}
           onNext={() => setStep(Step.Confirmation)}
           members={augmentedAccounts}
-          onMembersChange={setAddedAccounts}
+          setAddedAccounts={setAddedAccounts}
         />
       ) : step === Step.Confirmation ? (
         <Confirmation

--- a/apps/multisig/src/layouts/AddVault/MultisigConfig/index.tsx
+++ b/apps/multisig/src/layouts/AddVault/MultisigConfig/index.tsx
@@ -11,8 +11,7 @@ type Props = {
   header?: string
   members: AugmentedAccount[]
   threshold: number
-  setAddedAccounts?: React.Dispatch<React.SetStateAction<Address[]>>
-  onMembersChange?: React.Dispatch<React.SetStateAction<Address[]>>
+  setAddedAccounts: React.Dispatch<React.SetStateAction<Address[]>>
   onThresholdChange: (threshold: number) => void
   onBack: () => void
   onNext: () => void
@@ -34,7 +33,7 @@ export const MultisigConfig: React.FC<Props> = ({
         <h4 className="text-[14px] text-center font-bold mb-[4px]">{header}</h4>
         <h1>Multisig Configuration</h1>
       </div>
-      <AddMembers setAddedAccounts={setAddedAccounts!} augmentedAccounts={members} chain={chain} />
+      <AddMembers setAddedAccounts={setAddedAccounts} augmentedAccounts={members} chain={chain} />
       <ThresholdSettings membersCount={members.length} onChange={onThresholdChange} threshold={threshold} />
       <CancleOrNext
         block


### PR DESCRIPTION
### Description

Fix `setAddedAccounts` missing prop when adding an address to an imported multisig.

### 🖼️ **Screenshots:***


https://github.com/user-attachments/assets/4ca6a8d1-a376-459a-98de-b381a5776985

