### PR TITLE
fix: referendum link

### DIFF
--- a/apps/multisig/src/layouts/Overview/Transactions/VoteTransactionDetails.tsx
+++ b/apps/multisig/src/layouts/Overview/Transactions/VoteTransactionDetails.tsx
@@ -135,7 +135,7 @@ export const VoteExpandedDetails: React.FC<Props> = ({ t }) => {
           {!!t.multisig.chain.polkaAssemblyUrl ? (
             <a
               className="text-[16px] text-offWhite hover:text-primary flex items-center"
-              href={`${t.multisig.chain.polkaAssemblyUrl}/referenda/${referendumId}`}
+              href={`${t.multisig.chain.polkaAssemblyUrl}/referenda/${String(referendumId).replace(/,/g, '')}`}
               target="_blank"
               rel="noopener noreferrer"
             >


### PR DESCRIPTION
# Description

Fix referendum link. 

`referendumId` is being used as an url param, but referendum ids bigger then 1000 have a thousand separator comma.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Ready to merge

### 🖼️ **Screenshots:**


https://github.com/user-attachments/assets/b5597e20-708d-476c-84ef-e241b46f8238

