### PR TITLE
Fix/csv upload apple numbers

### DIFF
--- a/apps/multisig/src/layouts/AddressBook/components/AddressBookHeader.tsx
+++ b/apps/multisig/src/layouts/AddressBook/components/AddressBookHeader.tsx
@@ -28,7 +28,7 @@ const parseCSV = async (file: File): Promise<ParsedPaginatedAddresses> => {
   const text = await file.text()
 
   const lines = text.split('\r\n')
-  const headers = lines[0]?.split(',')
+  const headers = lines[0]?.split(',').map(removeSurroundingCharacters)
   if (!headers) {
     return { rows: [], pageCount: 0, rowCount: 0, invalidRows }
   }

--- a/apps/multisig/src/layouts/AddressBook/components/AddressBookHeader.tsx
+++ b/apps/multisig/src/layouts/AddressBook/components/AddressBookHeader.tsx
@@ -16,6 +16,7 @@ import { PaginationState } from '@tanstack/react-table'
 import useUpsertAddresses from '@domains/offchain-data/address-book/hooks/useUpsertAddresses'
 import { CircularProgressIndicator } from '@talismn/ui'
 import { useSelectedMultisig } from '@domains/multisig'
+import { removeSurroundingCharacters } from '@util/strings'
 
 type ParsedPaginatedAddresses = PaginatedAddresses & {
   invalidRows: number[]
@@ -33,7 +34,7 @@ const parseCSV = async (file: File): Promise<ParsedPaginatedAddresses> => {
   }
 
   const rows: ContactAddress[] = lines.slice(1).map((line, index) => {
-    const data = line.split(',')
+    const data = line.split(',').map(removeSurroundingCharacters)
     const name = data[headers.indexOf('Name')]
     const csvAddress = data[headers.indexOf('Address')] ?? ''
     const address = Address.fromSs58(csvAddress)

--- a/apps/multisig/src/layouts/NewTransaction/Multisend/MultisendTable/index.tsx
+++ b/apps/multisig/src/layouts/NewTransaction/Multisend/MultisendTable/index.tsx
@@ -24,6 +24,7 @@ import { Address } from '@util/addresses'
 import { useToast } from '@components/ui/use-toast'
 import multisendCopyPastaGif from './multisend-copy-pasta.gif'
 import { CONFIG } from '@lib/config'
+import { removeSurroundingCharacters } from '@util/strings'
 
 type Props = {
   contacts?: AddressWithName[]
@@ -287,7 +288,10 @@ export const MultiSendTable: React.FC<Props> = ({ chainGenesisHash, contacts, di
             const [file] = files
             if (!file) return
             const text = await file.text()
-            const lines = text.split('\n').map(line => line.replaceAll('\r', '').split(','))
+            const lines = text
+              .split('\n')
+              .map(line => line.replaceAll('\r', '').split(',').map(removeSurroundingCharacters))
+
             const headerIndex = lines.findIndex(line => line.includes('Recipient') && line.includes('Amount'))
 
             let addressCol = 0

--- a/apps/multisig/src/util/strings.tsx
+++ b/apps/multisig/src/util/strings.tsx
@@ -9,3 +9,10 @@ export const parseURL = (url: string) => {
     return false
   }
 }
+
+export const removeSurroundingCharacters = (input: string): string => {
+  // Regular expression to remove the first and last characters if they are not letters or numbers
+  // Sample input: '“Santos”'
+  // Sample output: 'Santos'
+  return input.replace(/^[^a-zA-Z0-9]+|[^a-zA-Z0-9]+$/g, '')
+}


### PR DESCRIPTION
## Description

Handle parsing CSV uploads where each cell is surrounded by non alphanumeric characters

### 🧪 **How to test:**

1- Go to`/address-book`
2- Download any csv from [this folder](https://drive.google.com/drive/folders/1DI5v2copmuKYU1Fcw60sJt4U4NULCC4g?dmr=1&ec=wgc-drive-globalnav-goto)
3- Import CSV

Expected result: CSV should be parsed correctly and data displayed.

### 🗒️ **Notes:**

Also added this CSV parsing function to Multi-send