### PR TITLE
fix: updated bittensor rpc url

### DIFF
--- a/apps/multisig/config.ts
+++ b/apps/multisig/config.ts
@@ -28,7 +28,7 @@ export const SUPPORTED_CHAINS: Record<string, SupportedChain> = {
   'bittensor': {
     id: 'bittensor',
     subscanUrl: 'https://bittensor.com/scan',
-    rpcs: [{ url: `wss://entrypoint-finney.opentensor.ai/` }],
+    rpcs: [{ url: 'wss://bittensor-finney.api.onfinality.io/ws?apikey=' }],
   },
   'polkadot-asset-hub': { id: 'polkadot-asset-hub' },
   'kusama-asset-hub': { id: 'kusama-asset-hub' },

--- a/apps/multisig/src/domains/chains/generated-chains.ts
+++ b/apps/multisig/src/domains/chains/generated-chains.ts
@@ -262,7 +262,7 @@ export const supportedChains: Chain<SupportedChainIds>[] = [
     },
     rpcs: [
       {
-        url: 'wss://entrypoint-finney.opentensor.ai/',
+        url: 'wss://bittensor-finney.api.onfinality.io/ws?apikey=',
       },
     ],
     ss58Prefix: 42,

--- a/apps/multisig/src/domains/chains/pjs-api.ts
+++ b/apps/multisig/src/domains/chains/pjs-api.ts
@@ -32,6 +32,8 @@ const defaultPjsApiSelector = selectorFamily({
         rpcs: [],
       }
 
+    console.log({ rpcs })
+
     // Return a dummy provider when rpcs are not known
     if (rpcs.length === 0) return ApiPromise.create({ provider: new WsProvider([]) })
 

--- a/apps/multisig/src/domains/chains/pjs-api.ts
+++ b/apps/multisig/src/domains/chains/pjs-api.ts
@@ -32,8 +32,6 @@ const defaultPjsApiSelector = selectorFamily({
         rpcs: [],
       }
 
-    console.log({ rpcs })
-
     // Return a dummy provider when rpcs are not known
     if (rpcs.length === 0) return ApiPromise.create({ provider: new WsProvider([]) })
 


### PR DESCRIPTION
## Description

Bittensor RPC only stores the latest 256 blocks, then they are pruned. An archive node is required In order to access the historical data of a given block older than the latest block - 256.

Regression of: https://github.com/TalismanSociety/signet-web/pull/62

Caused by:  https://github.com/TalismanSociety/signet-web/pull/63

### 🧪 **How to test:**

- Create and sign a transaction
- Transaction should appear on "Pending" tab
- Wait 360 blocks

Expected:

- Transaction should still appear on "Pending" tab

### 🖼️ **Screenshots:**
Note: Yesterday's transaction is over 256 blocks.

![Screenshot 2025-02-20 at 11 36 14](https://github.com/user-attachments/assets/11f2bee7-d72f-41ea-998f-0a743d0acbc7)
