### PR TITLE
Fix: Incorrect "Insufficient Balance" errors in Transaction Sidesheet

### DIFF
--- a/apps/multisig/src/components/TransactionSidesheet/TransactionSidesheetFooter.tsx
+++ b/apps/multisig/src/components/TransactionSidesheet/TransactionSidesheetFooter.tsx
@@ -79,10 +79,8 @@ export const SignerCta: React.FC<{
     // Get the token being transferred
     const outgoingToken = t.decoded?.type === TransactionType.Vote ? voteSum?.token : sumOutgoing?.token
 
-    if (!outgoingToken) {
-      console.error('No outgoing token found')
-      return false
-    }
+    // No outgoing token means no tokens are being transferred (e.g. ChangeConfig)
+    if (!outgoingToken) return true
 
     const availableBalance =
       balances?.find(({ address, chainId, tokenId }) => {

--- a/apps/multisig/src/components/TransactionSidesheet/TransactionSidesheetFooter.tsx
+++ b/apps/multisig/src/components/TransactionSidesheet/TransactionSidesheetFooter.tsx
@@ -113,7 +113,17 @@ export const SignerCta: React.FC<{
   ])
 
   const connectedAccountHasEnoughBalance: boolean = useMemo(() => {
-    if (asDraft || existentialDepositLoadable.state === 'loading') return true
+    // If the transaction is being saved as draft, we don't need to check for balance. Similarly, if the existential deposit or multisig deposit
+    //  total is still loading or errored, we optimistically assume the user has enough balance to proceed, as we don't want to block them from
+    //  saving drafts or approving transactions due to a temporary loading state or error in fetching on-chain constants.
+    if (
+      asDraft ||
+      existentialDepositLoadable.state === 'loading' ||
+      existentialDepositLoadable.state === 'hasError' ||
+      multisigDepositTotal.state === 'loading' ||
+      multisigDepositTotal.state === 'hasError'
+    )
+      return true
 
     let txCost = BigInt(fee?.amount.toString() ?? 0) + BigInt(existentialDepositLoadable.contents.amount.toString())
     if (firstApproval) {
@@ -140,6 +150,7 @@ export const SignerCta: React.FC<{
     fee?.amount,
     firstApproval,
     balances,
+    multisigDepositTotal.state,
     multisigDepositTotal.contents.amount,
     user,
     t.multisig.chain.id,


### PR DESCRIPTION


## What was done

Fixed two bugs in `TransactionSidesheetFooter` that caused false "Insufficient Balance" messages:

### 1. False "Insufficient Multisig Balance" on non-transfer transactions

When approving transactions that don't transfer tokens (e.g. **ChangeConfig**), `multisigHasEnoughBalance` returned `false` because no outgoing token exists for these transaction types. The code treated a missing outgoing token as an error, blocking the approval.

**Fix:** Return `true` when there is no outgoing token, since no balance check is needed for non-transfer transactions.

### 2. Unsafe access to `multisigDepositTotal` loadable contents

`connectedAccountHasEnoughBalance` only checked the loading state of `existentialDepositLoadable`, but not `multisigDepositTotal`. When `multisigDepositTotal` was still loading, its `.contents` is a `Promise`, causing `.amount?.toString()` to silently return `undefined` and fall through to `?? 0` — under-counting the actual transaction cost. In error state, `.contents` is an `Error` object, which could throw or produce garbage values.

**Fix:** Gate the balance check on both `existentialDepositLoadable` and `multisigDepositTotal` loading/error states, returning `true` optimistically until both values are resolved.

## How to test

1. Create a **ChangeConfig** transaction (change signer configuration) — the approve button should no longer show "Insufficient Multisig Balance"
2. On a slow connection, approve a transaction while chain constants are still loading — the button should show "Approve" (not "Insufficient Balance") until the loadables resolve
